### PR TITLE
Added sort_by to list

### DIFF
--- a/lib/aiken/list.ak
+++ b/lib/aiken/list.ak
@@ -430,3 +430,82 @@ pub fn filter_map(xs: List<a>, f: fn(a) -> Option<b>) -> List<b> {
 pub fn flat_map(xs: List<a>, f: fn(a) -> List<b>) -> List<b> {
   foldr(xs, fn(x, ys) { concat(f(x), ys) }, [])
 }
+
+/// Sort list by a certain predicate.
+///
+/// ----- TODO: Add support for writing tests.
+///
+/// test sort_by_1() {
+///   let xs = [4, 3, 2, 1]
+///   sort_by(xs, fn(a, b) { a - b }) == [1, 2, 3, 4]
+/// }
+pub fn sort_by(xs: List<a>, f: fn(a, a) -> Int) -> List<a> {
+  do_merge_all(do_sequences(xs, f), f)
+}
+
+fn do_sequences(xs: List<a>, f: fn(a, a) -> Int) -> List<List<a>> {
+  when xs is {
+    [x, y, ..rest] ->
+      if f(x, y) > 0 {
+        do_descending(y, [x], rest, f)
+      } else {
+        do_ascending(y, [x], rest, f)
+      }
+    xs -> [xs]
+  }
+}
+
+fn do_descending(
+  x: a,
+  xs: List<a>,
+  rest: List<a>,
+  f: fn(a, a) -> Int,
+) -> List<List<a>> {
+  let [y, ..ys] = rest
+  if f(x, y) > 0 {
+    do_descending(y, [x, ..xs], ys, f)
+  } else {
+    [[x, ..xs], ..do_sequences(rest, f)]
+  }
+}
+
+fn do_ascending(
+  x: a,
+  xs: List<a>,
+  rest: List<a>,
+  f: fn(a, a) -> Int,
+) -> List<List<a>> {
+  let [y, ..ys] = rest
+  if f(x, y) <= 0 {
+    do_ascending(y, concat(xs, [x]), ys, f)
+  } else {
+    [concat(xs, [x]), ..do_sequences(rest, f)]
+  }
+}
+
+fn do_merge(xs: List<a>, ys: List<a>, f: fn(a, a) -> Int) -> List<a> {
+  when [xs, ys] is {
+    [[], ys] -> ys
+    [xs, []] -> xs
+    [[x, ..xs2], [y, ..ys2]] ->
+      if f(x, y) > 0 {
+        [y, ..do_merge(xs, ys2, f)]
+      } else {
+        [x, ..do_merge(xs2, ys, f)]
+      }
+  }
+}
+
+fn do_merge_pairs(xs: List<List<a>>, f: fn(a, a) -> Int) -> List<List<a>> {
+  when xs is {
+    [x, y, ..rest] -> [do_merge(x, y, f), ..do_merge_pairs(rest, f)]
+    xs -> xs
+  }
+}
+
+fn do_merge_all(xs: List<List<a>>, f: fn(a, a) -> Int) -> List<a> {
+  when xs is {
+    [x] -> x
+    xs -> do_merge_all(do_merge_pairs(xs, f), f)
+  }
+}


### PR DESCRIPTION
I'm not sure if there is any plan for sorting, especially handling Ordering in some way. But I thought I'm going create now a `sort_by` function for lists. The order is determined by `Int` (JavaScript like):
```
x == 0 => EQ
x < 0  => LT
x > 0  => GT
```
e.g. sort a list of `Int` in ascending order:
```
list.sort_by([4,2,1,3], fn(a,b) { a - b })
```

It's a merge sort, which was pretty much taken from the PlutusTx repo.
Unfortunately I couldn't test it yet since some things seem to be missing in Aiken.