### PR TITLE
Remove labeled args, ignore JetBrains IDE config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.idea/

--- a/lib/aiken/string.ak
+++ b/lib/aiken/string.ak
@@ -24,7 +24,7 @@ test concat_2() {
 }
 
 test concat_3() {
-  concat(left: "Hello", right: ", World!") == "Hello, World!"
+  concat("Hello", ", World!") == "Hello, World!"
 }
 
 /// Convert a `ByteArray` into a `String`


### PR DESCRIPTION
It appears that newer versions of Aiken don't support labeled args in functions:
```
  Error: aiken::check
    × Checking
    ╰─▶ Unexpected labeled argument
        
        left
        
      ╭─[./time_locked/build/packages/aiken-lang-stdlib/lib/aiken/string.ak:26:1]
   26 │ test concat_3() {
   27 │   concat(left: "Hello", right: ", World!") == "Hello, World!"
      ·          ─────────────
   28 │ }
      ╰────
```

Removing those names.

PR also includes adding `.idea/` to `.gitignore` for us plebes.