### PR TITLE
aiken/option.{flatten}

### DIFF
--- a/lib/aiken/list.ak
+++ b/lib/aiken/list.ak
@@ -230,15 +230,13 @@ pub fn flat_map(self: List<a>, with: fn(a) -> List<b>) -> List<b> {
   foldr(self, fn(x, xs) { concat(with(x), xs) }, [])
 }
 
-// TODO: acceptance_test 034
-//
-// test flat_map_1() {
-//   flat_map([], fn(a) { [a] }) == []
-// }
-//
-// test flat_map_2() {
-//   flat_map([1, 2, 3], fn(a) { [a, a] }) == [1, 1, 2, 2, 3, 3]
-// }
+test flat_map_1() {
+  flat_map([], fn(a) { [a] }) == []
+}
+
+test flat_map_2() {
+  flat_map([1, 2, 3], fn(a) { [a, a] }) == [1, 1, 2, 2, 3, 3]
+}
 
 /// Reduce a list from left to right.
 pub fn foldl(self: List<a>, with: fn(a, b) -> b, zero: b) -> b {

--- a/lib/aiken/option.ak
+++ b/lib/aiken/option.ak
@@ -129,3 +129,41 @@ test and_then_3() {
     |> and_then(try_decrement)
   result == None
 }
+
+/// Converts from `Option<Option<T>>` to `Option<T>`.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```aiken
+/// use aiken/option
+///
+/// let x: Option<Option<Int>> = Some(Some(6))
+/// Some(6) == flatten(x)
+///
+/// let x: Option<Option<Int>> = Some(None)
+/// None == flatten(x)
+///
+/// let x: Option<Option<Int>> = None
+/// None == flatten(x)
+/// ```
+///
+/// Flattening only removes one level of nesting at a time:
+///
+/// ```aiken
+/// let x: Option<Option<Option<u32>>> = Some(Some(Some(6)))
+/// Some(Some(6)) == flatten(x)
+/// Some(6) == x |> flatten |> flatten
+/// ```
+pub fn flatten(opt: Option<Option<a>>) -> Option<a> {
+  when opt is {
+    Some(inner) -> inner
+    None -> None
+  }
+}
+
+test flatten_1() {
+  let x: Option<Option<Int>> = Some(Some(6))
+  Some(6) == flatten(x)
+}


### PR DESCRIPTION
- added a function that converts `Option<Option<a>>` to `Option<a>`
  - only supports one level of nesting
- enabled some commented out list tests for flat_map