### PR TITLE
Added without_lovelace function

### DIFF
--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -65,6 +65,25 @@ pub fn without_lovelace(self: Value) -> Value {
   |> Value
 }
 
+test without_lovelace_1() {
+  let v = from_lovelace(1000000)
+  without_lovelace(v) == zero()
+}
+
+test without_lovelace_2() {
+  let v = from_lovelace(1000000)
+  let v2 = from_lovelace(50000000)
+  without_lovelace(v) == without_lovelace(v2)
+}
+
+test without_lovelace_3() {
+  let v =
+    from_asset(#[1, 2, 3], #[4, 5, 6], 100)
+    |> add(from_lovelace(100000000))
+  let v2 = from_asset(#[1, 2, 3], #[4, 5, 6], 100)
+  without_lovelace(v) == without_lovelace(v2) && without_lovelace(v) == v2
+}
+
 /// Negates quantities of all tokens (including Ada) in that `Value`.
 ///
 /// ```

--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -59,6 +59,12 @@ pub fn from_lovelace(quantity: Int) -> Value {
   from_asset(ada_policy_id, ada_asset_name, quantity)
 }
 
+/// Get a `Value` excluding Ada.
+pub fn without_lovelace(self: Value) -> Value {
+  dict.delete(self.inner, ada_policy_id)
+  |> Value
+}
+
 /// Negates quantities of all tokens (including Ada) in that `Value`.
 ///
 /// ```


### PR DESCRIPTION
This is very handy in cases where the lovelace quantity doesn't matter and lovelace only acts as the 'min ada'.