### PR TITLE
Added is_some and is_none functions to option

### DIFF
--- a/lib/aiken/option.ak
+++ b/lib/aiken/option.ak
@@ -188,3 +188,35 @@ test flatten_4() {
 
   Some(6) == result
 }
+
+/// Asserts whether an option is `Some`, irrespective of the value it contains.
+pub fn is_some(self: Option<a>) -> Bool {
+  when self is {
+    Some(_) -> True
+    _ -> False
+  }
+}
+
+test is_some_1() {
+  is_some(Some(0)) == True
+}
+
+test is_some_2() {
+  is_some(None) == False
+}
+
+/// Asserts whether an option is `None`.
+pub fn is_none(self: Option<a>) -> Bool {
+  when self is {
+    Some(_) -> False
+    _ -> True
+  }
+}
+
+test is_none_1() {
+  is_none(Some(0)) == False
+}
+
+test is_none_2() {
+  is_none(None) == True
+}


### PR DESCRIPTION
Adding is_some and is_none functions.

Typically I need those in two cases:
- on pattern matching guards to avoid having to create extra let
- with unit tests, when function which is being unit tested is actually returning an option


Consider example:
```
test get_proof_1() {
  let items = [#"aa", #"bb", #"cc", #"dd", #"ee", #"ff"]
  let mt = from_list(items)

  let p: Option<Proof> = get_proof(#"a1", mt)

  is_none(p)
}
```