### PR TITLE
chore: add to_list function for value

### DIFF
--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -290,3 +290,8 @@ test flatten_with_2() {
     },
   ) == [("a", "2"), ("b", "")]
 }
+
+/// Get the inner list holding the dictionary data.
+pub fn to_list(self: Value) -> List<(ByteArray, Dict<ByteArray, Int>)> {
+  dict.to_list(self.inner)
+}

--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -292,6 +292,10 @@ test flatten_with_2() {
 }
 
 /// Get the inner list holding the dictionary data.
-pub fn to_list(self: Value) -> List<(ByteArray, Dict<ByteArray, Int>)> {
+/// ***For advanced usage only, i.e. people like Microproofs***.
+/// If you are looking for a to_list function, use flatten or tokens
+pub fn to_list_advanced_usage(
+  self: Value,
+) -> List<(ByteArray, Dict<ByteArray, Int>)> {
   dict.to_list(self.inner)
 }


### PR DESCRIPTION
The why:

Sometimes you may just want access to the list of values to work directly with list destructuring. i.e. using expect or when

I consider this a more advanced usage, but there is quite the case for the cost savings. Like iterating over a larger amount of outputs. Calling tokens or flatten is not efficient enough once your outputs list reaches a large enough size. So in this case I wanted to add an escape hatch to work directly with the "List" of values.