### PR TITLE
Add invariants

### DIFF
--- a/lib/aiken/rats.ak
+++ b/lib/aiken/rats.ak
@@ -1,88 +1,284 @@
 // Rationals
 // Authors:
 // Micah Kendall
+// Ken Fritschy
 // <other authors go here>
 
+use aiken/math
+
+// Useful for using rationals in datums/redeemers which cannot have opaque types
 pub type UncheckedRational {
   numerator: Int,
   denominator: Int,
 }
 
+// Opaque type used primarily to ensure the sign of the Rational is managed
+// strictly in the numerator, it also ensures the Rational is always in its
+// irreducible state
 pub opaque type Rational {
   numerator: Int,
   denominator: Int,
 }
 
+// Converts an UncheckedRational to a Rational
 pub fn check_rational(num: UncheckedRational) -> Rational {
   let UncheckedRational { numerator, denominator } =
     num
   div_int(numerator, denominator)
 }
 
+// Multiplication
 pub fn mul(a: Rational, b: Rational) -> Rational {
-  Rational {
-    numerator: a.numerator * b.numerator,
-    denominator: a.denominator * b.denominator,
-  }
+  reduce(a.numerator * b.numerator, a.denominator * b.denominator)
 }
 
+test mul_1() {
+  let a =
+    div_int(2, 3) |> mul(div_int(3, 4))
+  a == Rational { numerator: 1, denominator: 2 }
+}
+
+test mul_2() {
+  let a =
+    div_int(-2, 3) |> mul(div_int(-3, 4))
+  a == Rational { numerator: 1, denominator: 2 }
+}
+
+// Division
 pub fn div(a: Rational, b: Rational) -> Rational {
-  Rational {
-    numerator: a.numerator * b.denominator,
-    denominator: a.denominator * b.numerator,
-  }
+  recip(b) |> mul(a)
 }
 
+test div_1() {
+  let a =
+    div_int(2, 3) |> div(div_int(3, 4))
+  a == Rational { numerator: 8, denominator: 9 }
+}
+
+test div_2() {
+  let a =
+    div_int(2, 3) |> div(div_int(-3, 4))
+  a == Rational { numerator: -8, denominator: 9 }
+}
+
+// Create a new Rational
 pub fn div_int(numerator: Int, denominator: Int) -> Rational {
   if denominator < 0 {
-    Rational { numerator: -numerator, denominator: -denominator }
+    reduce(-numerator, -denominator)
   } else {
-    Rational { numerator, denominator }
+    reduce(numerator, denominator)
   }
 }
 
+test div_int_1() {
+  div_int(2, 3) == Rational { numerator: 2, denominator: 3 }
+}
+
+test div_int_2() {
+  div_int(-2, 3) == Rational { numerator: -2, denominator: 3 }
+}
+
+test div_int_3() {
+  div_int(2, -3) == Rational { numerator: -2, denominator: 3 }
+}
+
+test div_int_4() {
+  div_int(2, 4) == Rational { numerator: 1, denominator: 2 }
+}
+
+test div_int_5() {
+  div_int(-2, -3) == Rational { numerator: 2, denominator: 3 }
+}
+
+test div_int_6() {
+  div_int(-2, -4) == Rational { numerator: 1, denominator: 2 }
+}
+
+// Addition
 pub fn add(a: Rational, b: Rational) -> Rational {
-  Rational {
-    numerator: a.numerator * b.denominator + b.numerator * a.denominator,
-    denominator: a.denominator * b.denominator,
-  }
+  reduce(
+    a.numerator * b.denominator + b.numerator * a.denominator,
+    a.denominator * b.denominator,
+  )
 }
 
+test add_1() {
+  let a =
+    div_int(2, 3) |> add(div_int(3, 4))
+  a == Rational { numerator: 17, denominator: 12 }
+}
+
+// Subtraction
 pub fn sub(a: Rational, b: Rational) -> Rational {
-  Rational {
-    numerator: a.numerator * b.denominator - b.numerator * a.denominator,
-    denominator: a.denominator * b.denominator,
-  }
+  reduce(
+    a.numerator * b.denominator - b.numerator * a.denominator,
+    a.denominator * b.denominator,
+  )
 }
 
+test sub_1() {
+  let a =
+    div_int(2, 3) |> sub(div_int(3, 4))
+  a == Rational { numerator: -1, denominator: 12 }
+}
+
+// Greater than
 pub fn gt(a: Rational, b: Rational) -> Bool {
   a.numerator * b.denominator > b.numerator * a.denominator
 }
 
+test gt_1() {
+  div_int(2, 3) |> gt(div_int(1, 3))
+}
+
+test gt_2() {
+  let a =
+    div_int(2, 3) |> gt(div_int(2, 3))
+  a == False
+}
+
+// Less than
 pub fn lt(a: Rational, b: Rational) -> Bool {
   a.numerator * b.denominator < b.numerator * a.denominator
 }
 
+test lt_1() {
+  div_int(2, 3) |> lt(div_int(3, 4))
+}
+
+test lt_2() {
+  let a =
+    div_int(2, 3) |> lt(div_int(2, 3))
+  a == False
+}
+
+// Greater than or equal
 pub fn ge(a: Rational, b: Rational) -> Bool {
   a.numerator * b.denominator >= b.numerator * a.denominator
 }
 
+test ge_1() {
+  div_int(2, 3) |> ge(div_int(1, 3))
+}
+
+test ge_2() {
+  div_int(2, 3) |> ge(div_int(2, 3))
+}
+
+// Less than or equal
 pub fn le(a: Rational, b: Rational) -> Bool {
   a.numerator * b.denominator <= b.numerator * a.denominator
 }
 
+test le_1() {
+  div_int(2, 3) |> le(div_int(3, 4))
+}
+
+test le_2() {
+  div_int(2, 3) |> le(div_int(2, 3))
+}
+
+// Equal
 pub fn eq(a: Rational, b: Rational) -> Bool {
-  a.numerator * b.denominator == b.numerator * a.denominator
+  a == b
 }
 
+test eq_1() {
+  div_int(2, 3) |> eq(div_int(2, 3))
+}
+
+// Not Equal
 pub fn neq(a: Rational, b: Rational) -> Bool {
-  a.numerator * b.denominator != b.numerator * a.denominator
+  a != b
 }
 
+test neq_1() {
+  div_int(2, 3) |> neq(div_int(1, 3))
+}
+
+// Create a new Rational from an Int
 pub fn from_int(a: Int) -> Rational {
   Rational { numerator: a, denominator: 1 }
 }
 
+test from_int_1() {
+  from_int(3) == div_int(3, 1)
+}
+
+// Truncate a Rational to convert it to an Int
 pub fn truncate(a: Rational) -> Int {
   a.numerator / a.denominator
+}
+
+test truncate_1() {
+  let a =
+    div_int(8, 3) |> truncate
+  a == 2
+}
+
+// Change the sign of a Rational
+pub fn neg(a: Rational) -> Rational {
+  Rational { numerator: -a.numerator, denominator: a.denominator }
+}
+
+test neg_1() {
+  let a =
+    div_int(2, 3) |> neg
+  a == Rational { numerator: -2, denominator: 3 }
+}
+
+// Absolute value of a Rational
+pub fn abs(a: Rational) -> Rational {
+  Rational { numerator: math.abs(a.numerator), denominator: a.denominator }
+}
+
+test abs_1() {
+  let a =
+    div_int(-2, 3) |> abs
+  a == Rational { numerator: 2, denominator: 3 }
+}
+
+// Reciprocal of a Rational
+pub fn recip(a: Rational) -> Rational {
+  if a.numerator < 0 {
+    Rational { numerator: -a.denominator, denominator: -a.numerator }
+  } else if a.numerator > 0 {
+    Rational { numerator: a.denominator, denominator: a.numerator }
+  } else {
+    error @"Denominator cannot be 0"
+  }
+}
+
+test recip_1() {
+  let a =
+    div_int(2, 3) |> recip
+  a == Rational { numerator: 3, denominator: 2 }
+}
+
+test recip_2() {
+  let a =
+    div_int(-2, 3) |> recip
+  a == Rational { numerator: -3, denominator: 2 }
+}
+
+fn gcd(a: Int, b: Int) -> Int {
+  do_gcd(math.abs(a), math.abs(b))
+}
+
+fn do_gcd(a: Int, b: Int) -> Int {
+  if b == 0 {
+    a
+  } else {
+    do_gcd(b, a % b)
+  }
+}
+
+fn reduce(a: Int, b: Int) -> Rational {
+  if b == 0 {
+    error @"Denominator cannot be 0"
+  } else {
+    let d =
+      gcd(a, b)
+    Rational { numerator: a / d, denominator: b / d }
+  }
 }

--- a/lib/aiken/rats.ak
+++ b/lib/aiken/rats.ak
@@ -16,11 +16,7 @@ pub opaque type Rational {
 pub fn check_rational(num: UncheckedRational) -> Rational {
   let UncheckedRational { numerator, denominator } =
     num
-  if denominator < 0 {
-    Rational { numerator: -numerator, denominator: -denominator }
-  } else {
-    Rational { numerator, denominator }
-  }
+  div_int(numerator, denominator)
 }
 
 pub fn mul(a: Rational, b: Rational) -> Rational {
@@ -37,8 +33,12 @@ pub fn div(a: Rational, b: Rational) -> Rational {
   }
 }
 
-pub fn div_int(a: Int, b: Int) -> Rational {
-  Rational { numerator: a, denominator: b }
+pub fn div_int(numerator: Int, denominator: Int) -> Rational {
+  if denominator < 0 {
+    Rational { numerator: -numerator, denominator: -denominator }
+  } else {
+    Rational { numerator, denominator }
+  }
 }
 
 pub fn add(a: Rational, b: Rational) -> Rational {

--- a/lib/aiken/rats.ak
+++ b/lib/aiken/rats.ak
@@ -17,7 +17,7 @@ pub fn check_rational(num: UncheckedRational) -> Rational {
   let UncheckedRational { numerator, denominator } =
     num
   if denominator < 0 {
-    Rational { numerator: numerator * -1, denominator: denominator * -1 }
+    Rational { numerator: -numerator, denominator: -denominator }
   } else {
     Rational { numerator, denominator }
   }

--- a/lib/aiken/rats.ak
+++ b/lib/aiken/rats.ak
@@ -1,0 +1,73 @@
+// Rationals
+// Authors:
+// Micah Kendall
+// <other authors go here>
+
+pub type Rational {
+  numerator: Int,
+  denominator: Int,
+}
+
+pub fn mul(a: Rational, b: Rational) -> Rational {
+  Rational {
+    numerator: a.numerator * b.numerator,
+    denominator: a.denominator * b.denominator,
+  }
+}
+
+pub fn div(a: Rational, b: Rational) -> Rational {
+  Rational {
+    numerator: a.numerator * b.denominator,
+    denominator: a.denominator * b.numerator,
+  }
+}
+
+pub fn div_int(a: Int, b: Int) -> Rational {
+  Rational { numerator: a, denominator: b }
+}
+
+pub fn add(a: Rational, b: Rational) -> Rational {
+  Rational {
+    numerator: a.numerator * b.denominator + b.numerator * a.denominator,
+    denominator: a.denominator * b.denominator,
+  }
+}
+
+pub fn sub(a: Rational, b: Rational) -> Rational {
+  Rational {
+    numerator: a.numerator * b.denominator - b.numerator * a.denominator,
+    denominator: a.denominator * b.denominator,
+  }
+}
+
+pub fn gt(a: Rational, b: Rational) -> Bool {
+  a.numerator * b.denominator > b.numerator * a.denominator
+}
+
+pub fn lt(a: Rational, b: Rational) -> Bool {
+  a.numerator * b.denominator < b.numerator * a.denominator
+}
+
+pub fn ge(a: Rational, b: Rational) -> Bool {
+  a.numerator * b.denominator >= b.numerator * a.denominator
+}
+
+pub fn le(a: Rational, b: Rational) -> Bool {
+  a.numerator * b.denominator <= b.numerator * a.denominator
+}
+
+pub fn eq(a: Rational, b: Rational) -> Bool {
+  a.numerator * b.denominator == b.numerator * a.denominator
+}
+
+pub fn neq(a: Rational, b: Rational) -> Bool {
+  a.numerator * b.denominator != b.numerator * a.denominator
+}
+
+pub fn from_int(a: Int) -> Rational {
+  Rational { numerator: a, denominator: 1 }
+}
+
+pub fn truncate(a: Rational) -> Int {
+  a.numerator / a.denominator
+}

--- a/lib/aiken/rats.ak
+++ b/lib/aiken/rats.ak
@@ -3,9 +3,24 @@
 // Micah Kendall
 // <other authors go here>
 
-pub type Rational {
+pub type UncheckedRational {
   numerator: Int,
   denominator: Int,
+}
+
+pub opaque type Rational {
+  numerator: Int,
+  denominator: Int,
+}
+
+pub fn check_rational(num: UncheckedRational) -> Rational {
+  let UncheckedRational { numerator, denominator } =
+    num
+  if denominator < 0 {
+    Rational { numerator: numerator * -1, denominator: denominator * -1 }
+  } else {
+    Rational { numerator, denominator }
+  }
 }
 
 pub fn mul(a: Rational, b: Rational) -> Rational {


### PR DESCRIPTION
I changed eq/neq since we should now always maintain the irreducible form of the Rational as well as maintain the sign change always in the numerator. I'm not sure if it would be cheaper/better to check that the numerators and denominators are equal instead of checking the objects are equal.

I changed div because there is a case where you divide by a negative rational that winds up with a negative denominator

I added some basic tests, I'm not sure how I feel about them being directly under the function they are testing because it feels a bit cluttered when trying to just quickly get a feel for the interface, but that seems to be the pattern elsewhere in stdlib