### PR TITLE
[BUG] value.add to zero value 

### DIFF
--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -246,6 +246,21 @@ test add_3() {
   v == from_lovelace(6)
 }
 
+test add_4() {
+  let v =
+    zero()
+      |> add(#"acab", #"beef", 0)
+  v == zero()
+}
+
+test add_5() {
+  let v =
+    zero()
+      |> add(#"acab", #"beef", 0)
+      |> add(#"acab", #"beef", 0)
+  v == zero()
+}
+
 /// Extract the quantity of a given asset.
 pub fn quantity_of(
   self: Value,


### PR DESCRIPTION
Pushing 2 tests confirming that when there's a `zero` value and we `add` some token of the amount 0, we don't get `zero`, but we get 0 amount token in the value and then the comparison to `zero` fails. 