### PR TITLE
Retire `list.and` + `list.or`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.0 - unreleased
+
+### Removed
+
+- retired `list.and` and `list.or` because of the new keywords for logical op chaining.
+
 ## v1.4.0 - 2023-07-21
 
 ### Changed
@@ -28,25 +34,25 @@
 - [`transaction/value.to_minted_value`](https://aiken-lang.github.io/stdlib/aiken/transaction/value.html#to_minted_value): Convert from `Value` to `MintedValue`
 - [`transaction/bytearray.to_hex`](https://aiken-lang.github.io/stdlib/aiken/bytearray.html#to_hex): Convert a `ByteArray` to a hex encoded `String`
 - [`math/rational`](https://aiken-lang.github.io/stdlib/aiken/math/rational.html): Working with rational numbers.
-    - [x] `abs`
-    - [x] `add`
-    - [x] `ceil`
-    - [x] `compare`
-    - [x] `compare_with`
-    - [x] `div`
-    - [x] `floor`
-    - [x] `from_int`
-    - [x] `mul`
-    - [x] `negate`
-    - [x] `new`
-    - [x] `proper_fraction`
-    - [x] `reciprocal`
-    - [x] `reduce`
-    - [x] `round`
-    - [x] `round_even`
-    - [x] `sub`
-    - [x] `truncate`
-    - [x] `zero`
+  - [x] `abs`
+  - [x] `add`
+  - [x] `ceil`
+  - [x] `compare`
+  - [x] `compare_with`
+  - [x] `div`
+  - [x] `floor`
+  - [x] `from_int`
+  - [x] `mul`
+  - [x] `negate`
+  - [x] `new`
+  - [x] `proper_fraction`
+  - [x] `reciprocal`
+  - [x] `reduce`
+  - [x] `round`
+  - [x] `round_even`
+  - [x] `sub`
+  - [x] `truncate`
+  - [x] `zero`
 
 ### Removed
 

--- a/lib/aiken/list.ak
+++ b/lib/aiken/list.ak
@@ -30,34 +30,6 @@ test all_3() {
   all([], fn(n) { n == 42 }) == True
 }
 
-/// Like [all](#all) but when elements are already booleans.
-///
-/// Note: an empty list always satisfies the predicate.
-///
-/// ```aiken
-/// list.and([]) == True
-/// list.and([True, True]) == True
-/// list.and([True, False]) == False
-/// ```
-pub fn and(self: List<Bool>) -> Bool {
-  when self is {
-    [] -> True
-    [x, ..xs] -> x && and(xs)
-  }
-}
-
-test and_1() {
-  and([True, True, True])
-}
-
-test and_2() {
-  !and([True, False, True])
-}
-
-test and_3() {
-  and([])
-}
-
 /// Determine if at least one element of the list satisfies the given predicate.
 ///
 /// Note: an empty list never satisfies the predicate.
@@ -161,39 +133,6 @@ test at_4() {
 
 test at_5() {
   at([1, 2, 3], 2) == Some(3)
-}
-
-/// Like [any](#any) but when elements are already booleans.
-///
-/// Note: an empty list never satisfies the predicate.
-///
-/// ```aiken
-/// list.or([]) == False
-/// list.or([True, True]) == True
-/// list.or([True, False]) == True
-/// list.or([False, False]) == False
-/// ```
-pub fn or(self: List<Bool>) -> Bool {
-  when self is {
-    [] -> False
-    [x, ..xs] -> x || or(xs)
-  }
-}
-
-test or_1() {
-  or([True, True])
-}
-
-test or_2() {
-  or([True, False, True])
-}
-
-test or_3() {
-  !or([])
-}
-
-test or_4() {
-  !or([False, False])
 }
 
 /// Merge two lists together.

--- a/lib/aiken/list.ak
+++ b/lib/aiken/list.ak
@@ -1270,7 +1270,7 @@ test zip_3() {
 ///
 /// ```aiken
 /// list.reduce([#[1], #[2], #[3]], #[0], bytearray.concat) == #[0, 1, 2, 3]
-/// list.reduce([True, False, True], False, fn(b, a) { or([b, a]) }) == True
+/// list.reduce([True, False, True], False, fn(b, a) { or { b, a } }) == True
 /// ```
 pub fn reduce(self: List<a>, zero: b, with: fn(b, a) -> b) -> b {
   foldl(self, zero, flip(with))
@@ -1285,7 +1285,7 @@ test reduce_2() {
 }
 
 test reduce_3() {
-  reduce([True, False, True], False, fn(left, right) { or([left, right]) }) == True
+  reduce([True, False, True], False, fn(left, right) { left || right }) == True
 }
 
 test reduce_4() {

--- a/lib/aiken/math/rational.ak
+++ b/lib/aiken/math/rational.ak
@@ -50,17 +50,12 @@ pub fn new(numerator: Int, denominator: Int) -> Option<Rational> {
 }
 
 test new_1() {
-  list.and(
-    [
-      (new(2, 0) == None)?,
-      (new(2, 3) == Some(ratio(2, 3)))?,
-      (new(-2, 3) == Some(ratio(-2, 3)))?,
-      (new(2, -3) == Some(ratio(-2, 3)))?,
-      (new(2, 4) == Some(ratio(2, 4)))?,
-      (new(-2, -3) == Some(ratio(2, 3)))?,
-      (new(-2, -4) == Some(ratio(2, 4)))?,
-    ],
-  )
+  (new(2, 0) == None)? && (new(2, 3) == Some(ratio(2, 3)))? && (new(-2, 3) == Some(
+    ratio(-2, 3),
+  ))? && (new(2, -3) == Some(ratio(-2, 3)))? && (new(2, 4) == Some(ratio(2, 4)))? && (new(
+    -2,
+    -3,
+  ) == Some(ratio(2, 3)))? && (new(-2, -4) == Some(ratio(2, 4)))?
 }
 
 /// Get the numerator of a rational value.
@@ -78,14 +73,9 @@ test numerator_1() {
   expect Some(y) = new(-2, 3)
   expect Some(z) = new(2, -3)
   expect Some(w) = new(-2, -3)
-  list.and(
-    [
-      (numerator(x) == 2)?,
-      (numerator(y) == -2)?,
-      (numerator(z) == -2)?,
-      (numerator(w) == 2)?,
-    ],
-  )
+  (numerator(x) == 2)? && (numerator(y) == -2)? && (numerator(z) == -2)? && (numerator(
+    w,
+  ) == 2)?
 }
 
 /// Get the denominator of a rational value.
@@ -103,14 +93,9 @@ test denominator_1() {
   expect Some(y) = new(-2, 3)
   expect Some(z) = new(2, -3)
   expect Some(w) = new(-2, -3)
-  list.and(
-    [
-      (denominator(x) == 3)?,
-      (denominator(y) == 3)?,
-      (denominator(z) == 3)?,
-      (denominator(w) == 3)?,
-    ],
-  )
+  (denominator(x) == 3)? && (denominator(y) == 3)? && (denominator(z) == 3)? && (denominator(
+    w,
+  ) == 3)?
 }
 
 /// A null `Rational`.
@@ -240,13 +225,9 @@ pub fn from_int(numerator: Int) -> Rational {
 }
 
 test from_int_1() {
-  list.and(
-    [
-      (from_int(14) == ratio(14, 1))?,
-      (from_int(-5) == ratio(-5, 1))?,
-      (from_int(0) == ratio(0, 1))?,
-    ],
-  )
+  (from_int(14) == ratio(14, 1))? && (from_int(-5) == ratio(-5, 1))? && (from_int(
+    0,
+  ) == ratio(0, 1))?
 }
 
 /// Returns the nearest `Int` between zero and a given `Rational`.
@@ -267,16 +248,11 @@ pub fn truncate(self: Rational) -> Int {
 }
 
 test truncate_1() {
-  [
-    (truncate(ratio(5, 2)) == 2)?,
-    (truncate(ratio(5, 3)) == 1)?,
-    (truncate(ratio(5, 4)) == 1)?,
-    (truncate(ratio(5, 5)) == 1)?,
-    (truncate(ratio(5, 6)) == 0)?,
-    (truncate(ratio(8, 3)) == 2)?,
-    (truncate(ratio(-14, 3)) == -4)?,
-  ]
-    |> list.and
+  (truncate(ratio(5, 2)) == 2)? && (truncate(ratio(5, 3)) == 1)? && (truncate(
+    ratio(5, 4),
+  ) == 1)? && (truncate(ratio(5, 5)) == 1)? && (truncate(ratio(5, 6)) == 0)? && (truncate(
+    ratio(8, 3),
+  ) == 2)? && (truncate(ratio(-14, 3)) == -4)?
 }
 
 /// Returns the greatest `Int` no greater than a given `Rational`
@@ -297,16 +273,11 @@ pub fn floor(self: Rational) -> Int {
 }
 
 test floor_1() {
-  [
-    (floor(ratio(5, 2)) == 2)?,
-    (floor(ratio(5, 3)) == 1)?,
-    (floor(ratio(5, 4)) == 1)?,
-    (floor(ratio(5, 5)) == 1)?,
-    (floor(ratio(5, 6)) == 0)?,
-    (floor(ratio(8, 3)) == 2)?,
-    (floor(ratio(-14, 3)) == -5)?,
-  ]
-    |> list.and
+  (floor(ratio(5, 2)) == 2)? && (floor(ratio(5, 3)) == 1)? && (floor(
+    ratio(5, 4),
+  ) == 1)? && (floor(ratio(5, 5)) == 1)? && (floor(ratio(5, 6)) == 0)? && (floor(
+    ratio(8, 3),
+  ) == 2)? && (floor(ratio(-14, 3)) == -5)?
 }
 
 /// Returns the smallest `Int` not less than a given `Rational`
@@ -331,17 +302,11 @@ pub fn ceil(self: Rational) -> Int {
 }
 
 test ceil_1() {
-  [
-    (ceil(ratio(13, 5)) == 3)?,
-    (ceil(ratio(15, 5)) == 3)?,
-    (ceil(ratio(16, 5)) == 4)?,
-    (ceil(ratio(-3, 5)) == 0)?,
-    (ceil(ratio(-5, 5)) == -1)?,
-    (ceil(ratio(-14, 3)) == -4)?,
-    (ceil(ratio(-14, 6)) == -2)?,
-    (ceil(ratio(44, 14)) == 4)?,
-  ]
-    |> list.and
+  (ceil(ratio(13, 5)) == 3)? && (ceil(ratio(15, 5)) == 3)? && (ceil(
+    ratio(16, 5),
+  ) == 4)? && (ceil(ratio(-3, 5)) == 0)? && (ceil(ratio(-5, 5)) == -1)? && (ceil(
+    ratio(-14, 3),
+  ) == -4)? && (ceil(ratio(-14, 6)) == -2)? && (ceil(ratio(44, 14)) == 4)?
 }
 
 /// Returns the proper fraction of a given `Rational` `r`. That is, a pair of
@@ -412,17 +377,11 @@ pub fn round(self: Rational) -> Int {
 }
 
 test round_1() {
-  [
-    (round(ratio(10, 7)) == 1)?,
-    (round(ratio(11, 7)) == 2)?,
-    (round(ratio(3, 2)) == 2)?,
-    (round(ratio(5, 2)) == 3)?,
-    (round(ratio(-3, 2)) == -1)?,
-    (round(ratio(-2, 3)) == -1)?,
-    (round(ratio(-10, 7)) == -1)?,
-    (round(ratio(4, 2)) == 2)?,
-  ]
-    |> list.and
+  (round(ratio(10, 7)) == 1)? && (round(ratio(11, 7)) == 2)? && (round(
+    ratio(3, 2),
+  ) == 2)? && (round(ratio(5, 2)) == 3)? && (round(ratio(-3, 2)) == -1)? && (round(
+    ratio(-2, 3),
+  ) == -1)? && (round(ratio(-10, 7)) == -1)? && (round(ratio(4, 2)) == 2)?
 }
 
 /// Round the argument to the nearest whole number. If the argument is
@@ -462,17 +421,11 @@ pub fn round_even(self: Rational) -> Int {
 }
 
 test round_even_1() {
-  [
-    (round_even(ratio(10, 7)) == 1)?,
-    (round_even(ratio(11, 7)) == 2)?,
-    (round_even(ratio(3, 2)) == 2)?,
-    (round_even(ratio(5, 2)) == 2)?,
-    (round_even(ratio(-3, 2)) == -2)?,
-    (round_even(ratio(-2, 3)) == -1)?,
-    (round_even(ratio(-10, 7)) == -1)?,
-    (round_even(ratio(4, 2)) == 2)?,
-  ]
-    |> list.and
+  (round_even(ratio(10, 7)) == 1)? && (round_even(ratio(11, 7)) == 2)? && (round_even(
+    ratio(3, 2),
+  ) == 2)? && (round_even(ratio(5, 2)) == 2)? && (round_even(ratio(-3, 2)) == -2)? && (round_even(
+    ratio(-2, 3),
+  ) == -1)? && (round_even(ratio(-10, 7)) == -1)? && (round_even(ratio(4, 2)) == 2)?
 }
 
 /// Change the sign of a `Rational`.
@@ -490,12 +443,9 @@ pub fn negate(a: Rational) -> Rational {
 }
 
 test negate_1() {
-  [
-    (negate(ratio(5, 2)) == ratio(-5, 2))?,
-    (negate(ratio(-5, 2)) == ratio(5, 2))?,
-    (negate(negate(ratio(5, 2))) == ratio(5, 2))?,
-  ]
-    |> list.and
+  (negate(ratio(5, 2)) == ratio(-5, 2))? && (negate(ratio(-5, 2)) == ratio(5, 2))? && (negate(
+    negate(ratio(5, 2)),
+  ) == ratio(5, 2))?
 }
 
 /// Absolute value of a `Rational`.
@@ -513,12 +463,9 @@ pub fn abs(self: Rational) -> Rational {
 }
 
 test abs_examples() {
-  [
-    (abs(ratio(5, 2)) == ratio(5, 2))?,
-    (abs(ratio(-5, 2)) == ratio(5, 2))?,
-    (abs(ratio(5, 2)) == abs(ratio(-5, 2)))?,
-  ]
-    |> list.and
+  (abs(ratio(5, 2)) == ratio(5, 2))? && (abs(ratio(-5, 2)) == ratio(5, 2))? && (abs(
+    ratio(5, 2),
+  ) == abs(ratio(-5, 2)))?
 }
 
 /// Reciprocal of a `Rational` number. That is, a new `Rational` where the
@@ -543,14 +490,13 @@ pub fn reciprocal(self: Rational) -> Option<Rational> {
 }
 
 test reciprocal_1() {
-  [
-    (reciprocal(ratio(5, 2)) == new(2, 5))?,
-    (reciprocal(ratio(-5, 2)) == new(-2, 5))?,
-    (reciprocal(ratio(0, 2)) == None)?,
-    (reciprocal(ratio(2, 3)) == new(3, 2))?,
-    (reciprocal(ratio(-2, 3)) == new(-3, 2))?,
-  ]
-    |> list.and
+  (reciprocal(ratio(5, 2)) == new(2, 5))? && (reciprocal(ratio(-5, 2)) == new(
+    -2,
+    5,
+  ))? && (reciprocal(ratio(0, 2)) == None)? && (reciprocal(ratio(2, 3)) == new(
+    3,
+    2,
+  ))? && (reciprocal(ratio(-2, 3)) == new(-3, 2))?
 }
 
 /// Reduce a rational to its irreducible form. This operation makes the
@@ -567,12 +513,10 @@ pub fn reduce(self: Rational) -> Rational {
 }
 
 test reduce_1() {
-  [
-    (reduce(ratio(80, 200)) == ratio(2, 5))?,
-    (reduce(ratio(-5, 1)) == ratio(-5, 1))?,
-    (reduce(ratio(0, 3)) == ratio(0, 1))?,
-  ]
-    |> list.and
+  (reduce(ratio(80, 200)) == ratio(2, 5))? && (reduce(ratio(-5, 1)) == ratio(
+    -5,
+    1,
+  ))? && (reduce(ratio(0, 3)) == ratio(0, 1))?
 }
 
 /// Compare two rationals for an ordering. This is safe to use even for
@@ -609,14 +553,10 @@ test compare_1() {
   expect Some(y) = new(3, 4)
   expect Some(z) = new(4, 6)
 
-  list.and(
-    [
-      compare(x, y) == Less,
-      compare(y, x) == Greater,
-      compare(x, x) == Equal,
-      compare(x, z) == Equal,
-    ],
-  )
+  compare(x, y) == Less && compare(y, x) == Greater && compare(x, x) == Equal && compare(
+    x,
+    z,
+  ) == Equal
 }
 
 /// Comparison of two rational values using a chosen heuristic. For example:


### PR DESCRIPTION
removes list.and + list.or to not collide with new keywords. We don't really need these now because of the new expressions which are more performant than list iteration.

https://github.com/aiken-lang/aiken/pull/706