### PR TITLE
Merkle patricia tree explorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [`math.pow2`](https://aiken-lang.github.io/stdlib/aiken/math.html#pow2): For faster exponentions for powers of two.
+- [`bytearray.test_bit`](https://aiken-lang.github.io/stdlib/aiken/bytearray.html#test_bit): For testing if a bit is set in a bytearray (MSB).
 
 ## v1.5.0 - 2023-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.0 - unreleased
+
+### Added
+
+- [`math.pow2`](https://aiken-lang.github.io/stdlib/aiken/math.html#pow2): For faster exponentions for powers of two.
+
 ## v1.5.0 - 2023-08-16
 
 ### Removed

--- a/lib/aiken/bytearray.ak
+++ b/lib/aiken/bytearray.ak
@@ -1,4 +1,5 @@
 use aiken/builtin
+use aiken/math
 use aiken/option
 
 /// Compare two bytearrays lexicographically.
@@ -452,4 +453,70 @@ test to_hex_1() {
 
 test to_hex_2() {
   to_hex("The quick brown fox jumps over the lazy dog") == @"54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67"
+}
+
+/// Checks whether a bit (Most-Significant-Bit first) is set in the given 'ByteArray'.
+///
+/// For example, consider the following bytearray: `#"8b765f"`. It can also be written as the
+/// following bits sequence:
+///
+/// | `8`    | `b`    | `7`    | `6`    | `5`    | `f`    |
+/// | ---    | ---    | ---    | ---    | ---    | ---    |
+/// | `1000` | `1011` | `0111` | `0110` | `0101` | `1111` |
+///
+/// And thus, we have:
+///
+/// ```aiken
+/// test_bit(#"8b765f", 0) == True
+/// test_bit(#"8b765f", 1) == False
+/// test_bit(#"8b765f", 2) == False
+/// test_bit(#"8b765f", 3) == False
+/// test_bit(#"8b765f", 7) == True
+/// test_bit(#"8b765f", 8) == False
+/// test_bit(#"8b765f", 20) == True
+/// test_bit(#"8b765f", 21) == True
+/// test_bit(#"8b765f", 22) == True
+/// test_bit(#"8b765f", 23) == True
+/// ```
+pub fn test_bit(self: ByteArray, ix: Int) -> Bool {
+  builtin.less_than_equals_bytearray(
+    #[128],
+    builtin.cons_bytearray(
+      builtin.index_bytearray(self, ix / 8) * math.pow2(ix % 8),
+      "",
+    ),
+  )
+}
+
+test test_bit_0() {
+  test_bit(#"8b765f", 0)
+}
+
+test test_bit_1() {
+  !test_bit(#"8b765f", 1)
+}
+
+test test_bit_2() {
+  !test_bit(#"8b765f", 2)
+}
+
+test test_bit_3() {
+  !test_bit(#"8b765f", 3)
+}
+
+test test_bit_7() {
+  test_bit(#"8b765f", 7)
+}
+
+test test_bit_8() {
+  !test_bit(#"8b765f", 8)
+}
+
+test test_bit_20_21_22_23() {
+  and {
+    test_bit(#"8b765f", 20),
+    test_bit(#"8b765f", 21),
+    test_bit(#"8b765f", 22),
+    test_bit(#"8b765f", 23),
+  }
 }

--- a/lib/aiken/math.ak
+++ b/lib/aiken/math.ak
@@ -18,6 +18,8 @@
 //// 3 * 4   // 12
 //// 10 % 3  // 1
 
+use aiken/builtin
+
 /// Calculate the absolute value of an integer.
 ///
 /// ```aiken
@@ -153,6 +155,63 @@ test pow_0_0() {
 
 test pow_513_3() {
   pow(513, 3) == 135005697
+}
+
+test pow_2_4() {
+  pow(2, 4) == 16
+}
+
+test pow_2_42() {
+  pow(2, 42) == 4398046511104
+}
+
+/// Calculates the power of 2 for a given exponent `e`. Much cheaper than
+/// using `pow(2, _)` for small exponents (0 < e < 256).
+///
+/// ```aiken
+/// math.pow2(-2) == 0
+/// math.pow2(0) == 1
+/// math.pow2(1) == 2
+/// math.pow2(4) == 16
+/// math.pow2(42) == 4398046511104
+/// ```
+pub fn pow2(e: Int) -> Int {
+  // do_pow2(e, 1)
+  if e < 8 {
+    if e < 0 {
+      0
+    } else {
+      builtin.index_bytearray(#[1, 2, 4, 8, 16, 32, 64, 128], e)
+    }
+  } else if e < 32 {
+    256 * pow2(e - 8)
+  } else {
+    4294967296 * pow2(e - 32)
+  }
+}
+
+test pow2_neg() {
+  pow2(-2) == 0
+}
+
+test pow2_0() {
+  pow2(0) == 1
+}
+
+test pow2_1() {
+  pow2(1) == 2
+}
+
+test pow2_4() {
+  pow2(4) == 16
+}
+
+test pow2_42() {
+  pow2(42) == 4398046511104
+}
+
+test pow2_256() {
+  pow2(256) == 115792089237316195423570985008687907853269984665640564039457584007913129639936
 }
 
 /// The logarithm in base `b` of an element using integer divisions.


### PR DESCRIPTION
- :round_pushpin: **Add math.pow2**
    The speed increased is realized by using a bytearray and 'index_bytearray' as a way to shortcircuit some of the lower-level exponentiation. This is similar to a slew of nested if statements but faster and relatively elegant.

- :round_pushpin: **Add bytearray.test_bit**
    Without any bitwise primitives, manipulating bits becomes rapidly expensive on the VM. Especially right shifts that require division on integers. However, there's a little trick we can use for getting the ith bit of a byte: 'cons_bytearray' will actually apply a free modulo by 256 (2^8) to its argument. So we can use this as a way to do cheap divisions, provided that we multiplied the base number by the corresponding delta beforehand. Testing for a bit is still an expensive operations, but this tricks makes it more bearable than a more 'naive' approach using recursion and divisions.
