### PR TITLE
Specialize Dict's key to ByteArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## UNRELEASED
+
+### Added
+
+N/A
+
+### Changed
+
+- Specialized all `Dict`'s key as `ByteArray`, and thus remove the need for passing an extra comparison function.
+
+### Removed
+
+N/A
+
 ## v1.8.0 - 2024-03-28
 
 ### Added

--- a/lib/aiken/alist.ak
+++ b/lib/aiken/alist.ak
@@ -1,9 +1,9 @@
-//// A module for working with Map Data.
+//// A module for working with AList Data.
 ////
-//// These Maps are non-ordered lists of key-value pairs,
+//// These ALists are non-ordered lists of key-value pairs,
 //// which preserve no invariant on the order of the keys or the duplication of keys.
 
-/// Remove a single key-value pair from the Map. If the key is not found, no changes are made.
+/// Remove a single key-value pair from the AList. If the key is not found, no changes are made.
 /// Duplicate keys are not removed. Only the **first** key found is removed.
 ///
 /// ```aiken
@@ -12,7 +12,7 @@
 /// map.remove_first([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
 /// map.remove_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("b", 2), Pair("a", 3)]
 /// ```
-pub fn remove_first(self: Map<key, value>, key k: key) -> Map<key, value> {
+pub fn remove_first(self: AList<key, value>, key k: key) -> AList<key, value> {
   when self is {
     [] ->
       []
@@ -45,7 +45,7 @@ test remove_first_4() {
   remove_first(fixture, "a") == [Pair("b", 2), Pair("a", 3)]
 }
 
-/// Remove a single key-value pair from the Map. If the key is not found, no changes are made.
+/// Remove a single key-value pair from the AList. If the key is not found, no changes are made.
 /// Duplicate keys are not removed. Only the **last** key found is removed.
 ///
 /// ```aiken
@@ -54,7 +54,7 @@ test remove_first_4() {
 /// map.remove_last([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
 /// map.remove_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("a", 1), Pair("b", 2)]
 /// ```
-pub fn remove_last(self: Map<key, value>, key k: key) -> Map<key, value> {
+pub fn remove_last(self: AList<key, value>, key k: key) -> AList<key, value> {
   when self is {
     [] ->
       []
@@ -92,7 +92,7 @@ test remove_last_4() {
   remove_last(fixture, "a") == [Pair("a", 1), Pair("b", 2)]
 }
 
-/// Remove all key-value pairs matching the key from the Map. If the key is not found, no changes are made.
+/// Remove all key-value pairs matching the key from the AList. If the key is not found, no changes are made.
 ///
 /// ```aiken
 /// map.remove_all([], "a") == []
@@ -100,7 +100,7 @@ test remove_last_4() {
 /// map.remove_all([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
 /// map.remove_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("b", 2)]
 /// ```
-pub fn remove_all(self: Map<key, value>, key k: key) -> Map<key, value> {
+pub fn remove_all(self: AList<key, value>, key k: key) -> AList<key, value> {
   when self is {
     [] ->
       []
@@ -141,7 +141,7 @@ test remove_all_4() {
 /// map.find_first([Pair("a", 1), Pair("b", 2)], 1) == Some("a")
 /// map.find_first([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == Some("a")
 /// ```
-pub fn find_first(self: Map<key, value>, v: value) -> Option<key> {
+pub fn find_first(self: AList<key, value>, v: value) -> Option<key> {
   when self is {
     [] -> None
     [Pair(k2, v2), ..rest] ->
@@ -177,7 +177,7 @@ test find_first_4() {
 /// map.find_last([Pair("a", 1), Pair("b", 2)], 1) == Some("a")
 /// map.find_last([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == Some("c")
 /// ```
-pub fn find_last(self: Map<key, value>, v: value) -> Option<key> {
+pub fn find_last(self: AList<key, value>, v: value) -> Option<key> {
   when self is {
     [] -> None
     [Pair(k2, v2), ..rest] ->
@@ -216,7 +216,7 @@ test find_last_4() {
 /// map.find_all([Pair("a", 1), Pair("b", 2)], 1) == ["a"]
 /// map.find_all([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == ["a", "c"]
 /// ```
-pub fn find_all(self: Map<key, value>, v: value) -> List<key> {
+pub fn find_all(self: AList<key, value>, v: value) -> List<key> {
   when self is {
     [] ->
       []
@@ -245,8 +245,8 @@ test find_all_4() {
   find_all([Pair("a", 14), Pair("b", 42), Pair("c", 14)], 14) == ["a", "c"]
 }
 
-/// Fold over the key-value pairs in a Map. The fold direction follows the
-/// order of elements in the Map and is done from right-to-left.
+/// Fold over the key-value pairs in a AList. The fold direction follows the
+/// order of elements in the AList and is done from right-to-left.
 ///
 /// ```aiken
 /// let fixture = [
@@ -258,7 +258,7 @@ test find_all_4() {
 /// map.foldr(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
 /// ```
 pub fn foldr(
-  self: Map<key, value>,
+  self: AList<key, value>,
   zero: result,
   with: fn(key, value, result) -> result,
 ) -> result {
@@ -300,7 +300,7 @@ test foldr_3() {
 /// map.foldl(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
 /// ```
 pub fn foldl(
-  self: Map<key, value>,
+  self: AList<key, value>,
   zero: result,
   with: fn(key, value, result) -> result,
 ) -> result {
@@ -331,7 +331,7 @@ test foldl_2() {
 /// map.get_first([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
 /// map.get_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(1)
 /// ```
-pub fn get_first(self: Map<key, value>, key k: key) -> Option<value> {
+pub fn get_first(self: AList<key, value>, key k: key) -> Option<value> {
   when self is {
     [] -> None
     [Pair(k2, v), ..rest] ->
@@ -372,7 +372,7 @@ test get_first_5() {
 /// map.get_last([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
 /// map.get_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(3)
 /// ```
-pub fn get_last(self: Map<key, value>, key k: key) -> Option<value> {
+pub fn get_last(self: AList<key, value>, key k: key) -> Option<value> {
   when self is {
     [] -> None
     [Pair(k2, v), ..rest] ->
@@ -415,7 +415,7 @@ test get_last_5() {
 /// map.get_all([Pair("a", 1), Pair("b", 2)], "a") == [1]
 /// map.get_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [1, 3]
 /// ```
-pub fn get_all(self: Map<key, value>, key k: key) -> List<value> {
+pub fn get_all(self: AList<key, value>, key k: key) -> List<value> {
   when self is {
     [] ->
       []
@@ -456,7 +456,7 @@ test get_all_5() {
 /// map.has_key([Pair("a", 1), Pair("b", 2)], "a") == True
 /// map.has_key([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == True
 /// ```
-pub fn has_key(self: Map<key, value>, k: key) -> Bool {
+pub fn has_key(self: AList<key, value>, k: key) -> Bool {
   when self is {
     [] -> False
     // || is lazy so this is fine
@@ -484,7 +484,7 @@ test has_key_5() {
   has_key([Pair("a", 14), Pair("b", 42), Pair("a", 42)], "a")
 }
 
-/// Extract all the keys present in a given `Map`.
+/// Extract all the keys present in a given `AList`.
 ///
 /// ```aiken
 /// map.keys([]) == []
@@ -492,7 +492,7 @@ test has_key_5() {
 /// map.keys([Pair("a", 1), Pair("b", 2)]) == ["a", "b"]
 /// map.keys([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == ["a", "b", "a"]
 /// ```
-pub fn keys(self: Map<key, value>) -> List<key> {
+pub fn keys(self: AList<key, value>) -> List<key> {
   when self is {
     [] ->
       []
@@ -521,9 +521,9 @@ test keys_3() {
 /// map.map(fixture, fn(_k, v) { v * 2 }) == [Pair("a", 200), Pair("b", 400)]
 /// ```
 pub fn map(
-  self: Map<key, value>,
+  self: AList<key, value>,
   with: fn(key, value) -> result,
-) -> Map<key, result> {
+) -> AList<key, result> {
   when self is {
     [] ->
       []
@@ -546,7 +546,7 @@ test map_2() {
   map(fixture, with: fn(_, v) { v + 1 }) == [Pair("a", 2), Pair("b", 3)]
 }
 
-/// Extract all the values present in a given `Map`.
+/// Extract all the values present in a given `AList`.
 ///
 /// ```aiken
 /// map.values([]) == []
@@ -554,7 +554,7 @@ test map_2() {
 /// map.values([Pair("a", 1), Pair("b", 2)]) == [1, 2]
 /// map.values([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == [1, 2, 3]
 /// ```
-pub fn values(self: Map<key, value>) -> List<value> {
+pub fn values(self: AList<key, value>) -> List<value> {
   when self is {
     [] ->
       []

--- a/lib/aiken/alist.ak
+++ b/lib/aiken/alist.ak
@@ -7,10 +7,10 @@
 /// Duplicate keys are not removed. Only the **first** key found is removed.
 ///
 /// ```aiken
-/// map.remove_first([], "a") == []
-/// map.remove_first([Pair("a", 1)], "a") == []
-/// map.remove_first([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
-/// map.remove_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("b", 2), Pair("a", 3)]
+/// alist.remove_first([], "a") == []
+/// alist.remove_first([Pair("a", 1)], "a") == []
+/// alist.remove_first([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
+/// alist.remove_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("b", 2), Pair("a", 3)]
 /// ```
 pub fn remove_first(self: AList<key, value>, key k: key) -> AList<key, value> {
   when self is {
@@ -49,10 +49,10 @@ test remove_first_4() {
 /// Duplicate keys are not removed. Only the **last** key found is removed.
 ///
 /// ```aiken
-/// map.remove_last([], "a") == []
-/// map.remove_last([Pair("a", 1)], "a") == []
-/// map.remove_last([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
-/// map.remove_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("a", 1), Pair("b", 2)]
+/// alist.remove_last([], "a") == []
+/// alist.remove_last([Pair("a", 1)], "a") == []
+/// alist.remove_last([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
+/// alist.remove_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("a", 1), Pair("b", 2)]
 /// ```
 pub fn remove_last(self: AList<key, value>, key k: key) -> AList<key, value> {
   when self is {
@@ -95,10 +95,10 @@ test remove_last_4() {
 /// Remove all key-value pairs matching the key from the AList. If the key is not found, no changes are made.
 ///
 /// ```aiken
-/// map.remove_all([], "a") == []
-/// map.remove_all([Pair("a", 1)], "a") == []
-/// map.remove_all([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
-/// map.remove_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("b", 2)]
+/// alist.remove_all([], "a") == []
+/// alist.remove_all([Pair("a", 1)], "a") == []
+/// alist.remove_all([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
+/// alist.remove_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("b", 2)]
 /// ```
 pub fn remove_all(self: AList<key, value>, key k: key) -> AList<key, value> {
   when self is {
@@ -133,13 +133,13 @@ test remove_all_4() {
   remove_all(fixture, "a") == [Pair("b", 2)]
 }
 
-/// Finds the first key in the map associated with a given value, if any.
+/// Finds the first key in the alist associated with a given value, if any.
 ///
 /// ```aiken
-/// map.find_first([], 1) == None
-/// map.find_first([Pair("a", 1)], 1) == Some("a")
-/// map.find_first([Pair("a", 1), Pair("b", 2)], 1) == Some("a")
-/// map.find_first([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == Some("a")
+/// alist.find_first([], 1) == None
+/// alist.find_first([Pair("a", 1)], 1) == Some("a")
+/// alist.find_first([Pair("a", 1), Pair("b", 2)], 1) == Some("a")
+/// alist.find_first([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == Some("a")
 /// ```
 pub fn find_first(self: AList<key, value>, v: value) -> Option<key> {
   when self is {
@@ -169,13 +169,13 @@ test find_first_4() {
   find_first([Pair("a", 14), Pair("b", 42), Pair("c", 14)], 14) == Some("a")
 }
 
-/// Finds the last key in the map associated with a given value, if any.
+/// Finds the last key in the alist associated with a given value, if any.
 ///
 /// ```aiken
-/// map.find_last([], 1) == None
-/// map.find_last([Pair("a", 1)], 1) == Some("a")
-/// map.find_last([Pair("a", 1), Pair("b", 2)], 1) == Some("a")
-/// map.find_last([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == Some("c")
+/// alist.find_last([], 1) == None
+/// alist.find_last([Pair("a", 1)], 1) == Some("a")
+/// alist.find_last([Pair("a", 1), Pair("b", 2)], 1) == Some("a")
+/// alist.find_last([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == Some("c")
 /// ```
 pub fn find_last(self: AList<key, value>, v: value) -> Option<key> {
   when self is {
@@ -208,13 +208,13 @@ test find_last_4() {
   find_last([Pair("a", 14), Pair("b", 42), Pair("c", 14)], 14) == Some("c")
 }
 
-/// Finds all keys in the map associated with a given value.
+/// Finds all keys in the alist associated with a given value.
 ///
 /// ```aiken
-/// map.find_all([], 1) == []
-/// map.find_all([Pair("a", 1)], 1) == ["a"]
-/// map.find_all([Pair("a", 1), Pair("b", 2)], 1) == ["a"]
-/// map.find_all([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == ["a", "c"]
+/// alist.find_all([], 1) == []
+/// alist.find_all([Pair("a", 1)], 1) == ["a"]
+/// alist.find_all([Pair("a", 1), Pair("b", 2)], 1) == ["a"]
+/// alist.find_all([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == ["a", "c"]
 /// ```
 pub fn find_all(self: AList<key, value>, v: value) -> List<key> {
   when self is {
@@ -255,7 +255,7 @@ test find_all_4() {
 ///   Pair(3, 300),
 /// ]
 ///
-/// map.foldr(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
+/// alist.foldr(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
 /// ```
 pub fn foldr(
   self: AList<key, value>,
@@ -287,7 +287,7 @@ test foldr_3() {
   foldr(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
 }
 
-/// Fold over the key-value pairs in a map. The fold direction follows keys
+/// Fold over the key-value pairs in a alist. The fold direction follows keys
 /// in ascending order and is done from left-to-right.
 ///
 /// ```aiken
@@ -297,7 +297,7 @@ test foldr_3() {
 ///   Pair(3, 300),
 /// ]
 ///
-/// map.foldl(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
+/// alist.foldl(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
 /// ```
 pub fn foldl(
   self: AList<key, value>,
@@ -322,14 +322,14 @@ test foldl_2() {
   ) == 56
 }
 
-/// Get the value in the map by its key.
+/// Get the value in the alist by its key.
 /// If multiple values with the same key exist, only the first one is returned.
 ///
 /// ```aiken
-/// map.get_first([], "a") == None
-/// map.get_first([Pair("a", 1)], "a") == Some(1)
-/// map.get_first([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
-/// map.get_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(1)
+/// alist.get_first([], "a") == None
+/// alist.get_first([Pair("a", 1)], "a") == Some(1)
+/// alist.get_first([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
+/// alist.get_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(1)
 /// ```
 pub fn get_first(self: AList<key, value>, key k: key) -> Option<value> {
   when self is {
@@ -363,14 +363,14 @@ test get_first_5() {
   get_first([Pair("a", 1), Pair("b", 2), Pair("c", 3)], "d") == None
 }
 
-/// Get the value in the map by its key.
+/// Get the value in the alist by its key.
 /// If multiple values with the same key exist, only the last one is returned.
 ///
 /// ```aiken
-/// map.get_last([], "a") == None
-/// map.get_last([Pair("a", 1)], "a") == Some(1)
-/// map.get_last([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
-/// map.get_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(3)
+/// alist.get_last([], "a") == None
+/// alist.get_last([Pair("a", 1)], "a") == Some(1)
+/// alist.get_last([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
+/// alist.get_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(3)
 /// ```
 pub fn get_last(self: AList<key, value>, key k: key) -> Option<value> {
   when self is {
@@ -407,13 +407,13 @@ test get_last_5() {
   get_last([Pair("a", 1), Pair("b", 2), Pair("c", 3)], "d") == None
 }
 
-/// Get all values in the map associated with a given key.
+/// Get all values in the alist associated with a given key.
 ///
 /// ```aiken
-/// map.get_all([], "a") == []
-/// map.get_all([Pair("a", 1)], "a") == [1]
-/// map.get_all([Pair("a", 1), Pair("b", 2)], "a") == [1]
-/// map.get_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [1, 3]
+/// alist.get_all([], "a") == []
+/// alist.get_all([Pair("a", 1)], "a") == [1]
+/// alist.get_all([Pair("a", 1), Pair("b", 2)], "a") == [1]
+/// alist.get_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [1, 3]
 /// ```
 pub fn get_all(self: AList<key, value>, key k: key) -> List<value> {
   when self is {
@@ -448,13 +448,13 @@ test get_all_5() {
   get_all([Pair("a", 1), Pair("b", 2), Pair("c", 3)], "d") == []
 }
 
-/// Check if a key exists in the map.
+/// Check if a key exists in the alist.
 ///
 /// ```aiken
-/// map.has_key([], "a") == False
-/// map.has_key([Pair("a", 1)], "a") == True
-/// map.has_key([Pair("a", 1), Pair("b", 2)], "a") == True
-/// map.has_key([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == True
+/// alist.has_key([], "a") == False
+/// alist.has_key([Pair("a", 1)], "a") == True
+/// alist.has_key([Pair("a", 1), Pair("b", 2)], "a") == True
+/// alist.has_key([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == True
 /// ```
 pub fn has_key(self: AList<key, value>, k: key) -> Bool {
   when self is {
@@ -487,10 +487,10 @@ test has_key_5() {
 /// Extract all the keys present in a given `AList`.
 ///
 /// ```aiken
-/// map.keys([]) == []
-/// map.keys([Pair("a", 1)]) == ["a"]
-/// map.keys([Pair("a", 1), Pair("b", 2)]) == ["a", "b"]
-/// map.keys([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == ["a", "b", "a"]
+/// alist.keys([]) == []
+/// alist.keys([Pair("a", 1)]) == ["a"]
+/// alist.keys([Pair("a", 1), Pair("b", 2)]) == ["a", "b"]
+/// alist.keys([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == ["a", "b", "a"]
 /// ```
 pub fn keys(self: AList<key, value>) -> List<key> {
   when self is {
@@ -513,12 +513,12 @@ test keys_3() {
   keys([Pair("a", 0), Pair("b", 0)]) == ["a", "b"]
 }
 
-/// Apply a function to all key-value pairs in a map, replacing the values.
+/// Apply a function to all key-value pairs in a alist, replacing the values.
 ///
 /// ```aiken
 /// let fixture = [Pair("a", 100), Pair("b", 200)]
 ///
-/// map.map(fixture, fn(_k, v) { v * 2 }) == [Pair("a", 200), Pair("b", 400)]
+/// alist.map(fixture, fn(_k, v) { v * 2 }) == [Pair("a", 200), Pair("b", 400)]
 /// ```
 pub fn map(
   self: AList<key, value>,
@@ -549,10 +549,10 @@ test map_2() {
 /// Extract all the values present in a given `AList`.
 ///
 /// ```aiken
-/// map.values([]) == []
-/// map.values([Pair("a", 1)]) == [1]
-/// map.values([Pair("a", 1), Pair("b", 2)]) == [1, 2]
-/// map.values([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == [1, 2, 3]
+/// alist.values([]) == []
+/// alist.values([Pair("a", 1)]) == [1]
+/// alist.values([Pair("a", 1), Pair("b", 2)]) == [1, 2]
+/// alist.values([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == [1, 2, 3]
 /// ```
 pub fn values(self: AList<key, value>) -> List<value> {
   when self is {

--- a/lib/aiken/bytearray.ak
+++ b/lib/aiken/bytearray.ak
@@ -278,8 +278,9 @@ test from_string_2() {
 }
 
 /// Add a byte element in front of a `ByteArray`. When the given byte is
-/// greater than 255, it wraps-around. So 256 is mapped to 0, 257 to 1, and so
-/// forth.
+/// greater than 255, it wraps-around. **PlutusV2 behavior** So 256 is mapped to 0, 257 to 1, and so
+/// forth. 
+/// In PlutusV3 this will error instead of wrapping around.
 ///
 /// ```aiken
 /// bytearray.push(#"", 0) == #"00"

--- a/lib/aiken/cbor.ak
+++ b/lib/aiken/cbor.ak
@@ -310,7 +310,7 @@ test diagnostic_10() {
 }
 
 test diagnostic_10_alt() {
-  let xs: Map<Int, Int> =
+  let xs: AList<Int, Int> =
     []
   diagnostic(xs) == @"{}"
 }

--- a/lib/aiken/cbor.ak
+++ b/lib/aiken/cbor.ak
@@ -51,7 +51,7 @@ test serialise_5() {
 }
 
 test serialise_6() {
-  serialise([(1, #"ff")]) == #"a10141ff"
+  serialise([(1, #"ff")]) == #"9f9f0141ffffff"
 }
 
 test serialise_7() {
@@ -60,6 +60,10 @@ test serialise_7() {
 
 test serialise_8() {
   serialise(None) == #"d87a80"
+}
+
+test serialise_9() {
+  serialise([Pair(1, #"ff")]) == #"a10141ff"
 }
 
 /// Obtain a String representation of _anything_. This is particularly (and only) useful for tracing
@@ -111,8 +115,7 @@ fn do_diagnostic(self: Data, builder: ByteArray) -> ByteArray {
     self,
     {
       // -------- Constr
-
-      let (constr, fields) = un_constr_data(self)
+      let Pair(constr, fields) = un_constr_data(self)
 
       // NOTE: This is fundamentally the same logic for serializing list. However, the compiler
       // doesn't support mutual recursion just yet, so we can't extract that logic in a separate
@@ -159,7 +162,7 @@ fn do_diagnostic(self: Data, builder: ByteArray) -> ByteArray {
             list.foldr(
               elems,
               (#"207d", builder),
-              fn(e: (Data, Data), st: (ByteArray, ByteArray)) {
+              fn(e: Pair<Data, Data>, st: (ByteArray, ByteArray)) {
                 let value =
                   do_diagnostic(e.2nd, append_bytearray(st.1st, st.2nd))
                 (
@@ -285,7 +288,11 @@ test diagnostic_6() {
 }
 
 test diagnostic_7() {
-  diagnostic([(1, #"ff")]) == @"{_ 1: h'FF' }"
+  diagnostic([(1, #"ff")]) == @"[_ [_ 1, h'FF']]"
+}
+
+test diagnostic_7_alt() {
+  diagnostic([Pair(1, #"ff")]) == @"{_ 1: h'FF' }"
 }
 
 test diagnostic_8() {
@@ -298,6 +305,12 @@ test diagnostic_9() {
 
 test diagnostic_10() {
   let xs: List<(Int, Int)> =
+    []
+  diagnostic(xs) == @"[]"
+}
+
+test diagnostic_10_alt() {
+  let xs: Map<Int, Int> =
     []
   diagnostic(xs) == @"{}"
 }

--- a/lib/aiken/dict.ak
+++ b/lib/aiken/dict.ak
@@ -4,7 +4,7 @@
 //// which preserve some invariants. In particular, each key is only present
 //// once in the dictionary.
 
-use aiken/bytearray
+use aiken/builtin
 
 /// An opaque `Dict`. The type is opaque because the module maintains some
 /// invariant, namely: there's only one occurrence of a given key in the dictionary.
@@ -20,7 +20,7 @@ use aiken/bytearray
 ///   Dict<PolicyId, Dict<AssetName, Int>>
 /// ```
 pub opaque type Dict<key, value> {
-  inner: List<(key, value)>,
+  inner: List<(ByteArray, value)>,
 }
 
 /// Create a new map
@@ -39,35 +39,40 @@ const baz = #"62617a"
 
 fn fixture_1() {
   new()
-    |> insert(foo, 42, bytearray.compare)
-    |> insert(bar, 14, bytearray.compare)
+    |> insert(foo, 42)
+    |> insert(bar, 14)
 }
 
 /// Remove a key-value pair from the dictionary. If the key is not found, no changes are made.
 ///
 /// ```aiken
-/// use aiken/int
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(key: 1, value: 100, compare: int.compare)
-///     |> dict.insert(key: 2, value: 200, compare: int.compare)
-///     |> dict.delete(key: 1)
+///     |> dict.insert(key: "a", value: 100)
+///     |> dict.insert(key: "b", value: 200)
+///     |> dict.delete(key: "a")
 ///     |> dict.to_list()
 ///
-/// result == [(2, 200)]
+/// result == [("b", 200)]
 /// ```
-pub fn delete(self: Dict<key, value>, key: key) -> Dict<key, value> {
+pub fn delete(self: Dict<key, value>, key: ByteArray) -> Dict<key, value> {
   Dict { inner: do_delete(self.inner, key) }
 }
 
-fn do_delete(self: List<(key, value)>, key k: key) -> List<(key, value)> {
+fn do_delete(
+  self: List<(ByteArray, value)>,
+  key k: ByteArray,
+) -> List<(ByteArray, value)> {
   when self is {
     [] ->
       []
     [(k2, v2), ..rest] ->
-      if k == k2 {
-        rest
+      if builtin.less_than_equals_bytearray(k, k2) {
+        if k == k2 {
+          rest
+        } else {
+          self
+        }
       } else {
         [(k2, v2), ..do_delete(rest, k)]
       }
@@ -81,59 +86,74 @@ test delete_1() {
 test delete_2() {
   let m =
     new()
-      |> insert(foo, 14, bytearray.compare)
+      |> insert(foo, 14)
   delete(m, foo) == new()
 }
 
 test delete_3() {
   let m =
     new()
-      |> insert(foo, 14, bytearray.compare)
+      |> insert(foo, 14)
   delete(m, bar) == m
 }
 
 test delete_4() {
   let m =
     new()
-      |> insert(foo, 14, bytearray.compare)
-      |> insert(bar, 14, bytearray.compare)
+      |> insert(foo, 14)
+      |> insert(bar, 14)
   !has_key(delete(m, foo), foo)
 }
 
 test delete_5() {
   let m =
     new()
-      |> insert(foo, 14, bytearray.compare)
-      |> insert(bar, 14, bytearray.compare)
+      |> insert(foo, 14)
+      |> insert(bar, 14)
   has_key(delete(m, bar), foo)
+}
+
+test delete_6() {
+  let m =
+    new()
+      |> insert("aaa", 1)
+      |> insert("bbb", 2)
+      |> insert("ccc", 3)
+      |> insert("ddd", 4)
+      |> insert("eee", 5)
+      |> insert("fff", 6)
+      |> insert("ggg", 7)
+      |> insert("hhh", 8)
+      |> insert("iii", 9)
+      |> insert("jjj", 10)
+
+  delete(m, "bcd") == m
 }
 
 /// Keep only the key-value pairs that pass the given predicate.
 ///
 /// ```aiken
-/// use aiken/int
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(key: 1, value: 100, compare: int.compare)
-///     |> dict.insert(key: 2, value: 200, compare: int.compare)
-///     |> dict.insert(key: 3, value: 300, compare: int.compare)
-///     |> dict.filter(fn(k, _v) { k > 1 })
+///     |> dict.insert(key: "a", value: 100)
+///     |> dict.insert(key: "b", value: 200)
+///     |> dict.insert(key: "c", value: 300)
+///     |> dict.filter(fn(k, _v) { k != "a" })
 ///     |> dict.to_list()
 ///
-/// result == [(2, 200), (3, 300)]
+/// result == [("b", 200), ("c", 300)]
 /// ```
 pub fn filter(
   self: Dict<key, value>,
-  with: fn(key, value) -> Bool,
+  with: fn(ByteArray, value) -> Bool,
 ) -> Dict<key, value> {
   Dict { inner: do_filter(self.inner, with) }
 }
 
 fn do_filter(
-  self: List<(key, value)>,
-  with: fn(key, value) -> Bool,
-) -> List<(key, value)> {
+  self: List<(ByteArray, value)>,
+  with: fn(ByteArray, value) -> Bool,
+) -> List<(ByteArray, value)> {
   when self is {
     [] ->
       []
@@ -153,40 +173,34 @@ test filter_1() {
 test filter_2() {
   let expected =
     new()
-      |> insert(foo, 42, bytearray.compare)
+      |> insert(foo, 42)
   filter(fixture_1(), fn(_, v) { v > 14 }) == expected
 }
 
 test filter_3() {
   let expected =
     new()
-      |> insert(bar, 14, bytearray.compare)
+      |> insert(bar, 14)
   filter(fixture_1(), fn(k, _) { k == bar }) == expected
 }
 
 /// Finds a value in the dictionary, and returns the first key found to have that value.
 ///
 /// ```aiken
-/// use aiken/bytearray
-///
-/// let foo: ByteArray = #"00"
-/// let bar: ByteArray = #"11"
-/// let baz: ByteArray = #"22"
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(key: foo, value: 42, compare: bytearray.compare)
-///     |> dict.insert(key: bar, value: 14, compare: bytearray.compare)
-///     |> dict.insert(key: baz, value: 42, compare: bytearray.compare)
+///     |> dict.insert(key: "a", value: 42)
+///     |> dict.insert(key: "b", value: 14)
+///     |> dict.insert(key: "c", value: 42)
 ///     |> dict.find(42)
 ///
-/// result == Some(foo)
+/// result == Some("c")
 /// ```
-pub fn find(self: Dict<key, value>, value v: value) -> Option<key> {
+pub fn find(self: Dict<key, value>, value v: value) -> Option<ByteArray> {
   do_find(self.inner, v)
 }
 
-fn do_find(self: List<(key, value)>, value v: value) -> Option<key> {
+fn do_find(self: List<(ByteArray, value)>, value v: value) -> Option<ByteArray> {
   when self is {
     [] -> None
     [(k2, v2), ..rest] ->
@@ -205,7 +219,7 @@ test find_1() {
 test find_2() {
   find(
     new()
-      |> insert(foo, 14, bytearray.compare),
+      |> insert(foo, 14),
     14,
   ) == Some(foo)
 }
@@ -213,7 +227,7 @@ test find_2() {
 test find_3() {
   find(
     new()
-      |> insert(foo, 14, bytearray.compare),
+      |> insert(foo, 14),
     42,
   ) == None
 }
@@ -221,9 +235,9 @@ test find_3() {
 test find_4() {
   find(
     new()
-      |> insert(foo, 14, bytearray.compare)
-      |> insert(bar, 42, bytearray.compare)
-      |> insert(baz, 14, bytearray.compare),
+      |> insert(foo, 14)
+      |> insert(bar, 42)
+      |> insert(baz, 14),
     14,
   ) == Some(baz)
 }
@@ -232,13 +246,11 @@ test find_4() {
 /// in ascending order and is done from right-to-left.
 ///
 /// ```aiken
-/// use aiken/int
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(key: 1, value: 100, compare: int.compare)
-///     |> dict.insert(key: 2, value: 200, compare: int.compare)
-///     |> dict.insert(key: 3, value: 300, compare: int.compare)
+///     |> dict.insert(key: "a", value: 100)
+///     |> dict.insert(key: "b", value: 200)
+///     |> dict.insert(key: "c", value: 300)
 ///     |> dict.foldr(0, fn(_k, v, r) { v + r })
 ///
 /// result == 600
@@ -246,15 +258,15 @@ test find_4() {
 pub fn foldr(
   self: Dict<key, value>,
   zero: result,
-  with: fn(key, value, result) -> result,
+  with: fn(ByteArray, value, result) -> result,
 ) -> result {
   do_foldr(self.inner, zero, with)
 }
 
 fn do_foldr(
-  self: List<(key, value)>,
+  self: List<(ByteArray, value)>,
   zero: result,
-  with: fn(key, value, result) -> result,
+  with: fn(ByteArray, value, result) -> result,
 ) -> result {
   when self is {
     [] -> zero
@@ -274,13 +286,11 @@ test foldr_2() {
 /// in ascending order and is done from left-to-right.
 ///
 /// ```aiken
-/// use aiken/int
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(key: 1, value: 100, compare: int.compare)
-///     |> dict.insert(key: 2, value: 200, compare: int.compare)
-///     |> dict.insert(key: 3, value: 300, compare: int.compare)
+///     |> dict.insert(key: "a", value: 100)
+///     |> dict.insert(key: "b", value: 200)
+///     |> dict.insert(key: "c", value: 300)
 ///     |> dict.foldl(0, fn(_k, v, r) { v + r })
 ///
 /// result == 600
@@ -288,15 +298,15 @@ test foldr_2() {
 pub fn foldl(
   self: Dict<key, value>,
   zero: result,
-  with: fn(key, value, result) -> result,
+  with: fn(ByteArray, value, result) -> result,
 ) -> result {
   do_foldl(self.inner, zero, with)
 }
 
 fn do_foldl(
-  self: List<(key, value)>,
+  self: List<(ByteArray, value)>,
   zero: result,
-  with: fn(key, value, result) -> result,
+  with: fn(ByteArray, value, result) -> result,
 ) -> result {
   when self is {
     [] -> zero
@@ -316,51 +326,40 @@ test fold_2() {
 /// multiple times, the first occurrence prevails.
 ///
 /// ```aiken
-/// use aiken/int
-///
-/// let list = [(1, 100), (3, 300), (2, 200)]
+/// let list = [("a", 100), ("c", 300), ("b", 200)]
 ///
 /// let result =
-///   dict.from_list(list, int.compare)
+///   dict.from_list(list)
 ///     |> dict.to_list()
 ///
-/// result == [(1, 100), (2, 200), (3, 300)]
+/// result == [("a", 100), ("b", 200), ("c", 300)]
 /// ```
-pub fn from_list(
-  self: List<(key, value)>,
-  compare: fn(key, key) -> Ordering,
-) -> Dict<key, value> {
-  Dict { inner: do_from_list(self, compare) }
+pub fn from_list(self: List<(ByteArray, value)>) -> Dict<key, value> {
+  Dict { inner: do_from_list(self) }
 }
 
-fn do_from_list(
-  xs: List<(key, value)>,
-  compare: fn(key, key) -> Ordering,
-) -> List<(key, value)> {
+fn do_from_list(xs: List<(ByteArray, value)>) -> List<(ByteArray, value)> {
   when xs is {
     [] ->
       []
-    [(k, v), ..rest] -> do_insert(do_from_list(rest, compare), k, v, compare)
+    [(k, v), ..rest] -> do_insert(do_from_list(rest), k, v)
   }
 }
 
 test from_list_1() {
-  from_list([], bytearray.compare) == new()
+  from_list([]) == new()
 }
 
 test from_list_2() {
-  from_list([(foo, 42), (bar, 14)], bytearray.compare) == from_list(
-    [(bar, 14), (foo, 42)],
-    bytearray.compare,
-  )
+  from_list([(foo, 42), (bar, 14)]) == from_list([(bar, 14), (foo, 42)])
 }
 
 test from_list_3() {
-  from_list([(foo, 42), (bar, 14)], bytearray.compare) == fixture_1()
+  from_list([(foo, 42), (bar, 14)]) == fixture_1()
 }
 
 test from_list_4() {
-  from_list([(foo, 42), (bar, 14), (foo, 1337)], bytearray.compare) == fixture_1()
+  from_list([(foo, 42), (bar, 14), (foo, 1337)]) == fixture_1()
 }
 
 test bench_from_list() {
@@ -384,7 +383,6 @@ test bench_from_list() {
         ("abbb", 14),
         ("abba", 6),
       ],
-      bytearray.compare,
     )
 
   size(dict) == 16
@@ -395,40 +393,33 @@ test bench_from_list() {
 /// sorted.
 ///
 /// ```aiken
-/// use aiken/int
-///
-/// let list = [(1, 100), (2, 200), (3, 300)]
+/// let list = [("a", 100), ("b", 200), ("c", 300)]
 ///
 /// let result =
-///   dict.from_ascending_list(list, int.compare)
+///   dict.from_ascending_list(list)
 ///     |> dict.to_list()
 ///
-/// result == [(1, 100), (2, 200), (3, 300)]
+/// result == [("a", 100), ("b", 200), ("c", 300)]
 /// ```
 ///
 /// This is meant to be used to turn a list constructed off-chain into a `Dict`
 /// which has taken care of maintaining interval invariants. This function still
 /// performs a sanity check on all keys to avoid silly mistakes. It is, however,
 /// considerably faster than ['from_list'](from_list)
-pub fn from_ascending_list(
-  xs: List<(key, value)>,
-  compare: fn(key, key) -> Ordering,
-) -> Dict<key, value> {
-  let Void = check_ascending_list(xs, compare)
+pub fn from_ascending_list(xs: List<(ByteArray, value)>) -> Dict<key, value> {
+  let Void = check_ascending_list(xs)
   Dict { inner: xs }
 }
 
-fn check_ascending_list(
-  xs: List<(key, value)>,
-  compare: fn(key, key) -> Ordering,
-) {
+fn check_ascending_list(xs: List<(ByteArray, value)>) {
   when xs is {
     [] -> Void
     [_] -> Void
     [(x0, _), (x1, _) as e, ..rest] ->
-      when compare(x0, x1) is {
-        Less -> check_ascending_list([e, ..rest], compare)
-        _ -> fail @"keys in associative list aren't in ascending order"
+      if builtin.less_than_bytearray(x0, x1) {
+        check_ascending_list([e, ..rest])
+      } else {
+        fail @"keys in associative list aren't in ascending order"
       }
   }
 }
@@ -489,7 +480,6 @@ test bench_from_ascending_list() {
         ("bbba", 8),
         ("bbbb", 16),
       ],
-      bytearray.compare,
     )
 
   size(dict) == 16
@@ -498,27 +488,27 @@ test bench_from_ascending_list() {
 /// Get a value in the dict by its key.
 ///
 /// ```aiken
-/// use aiken/bytearray
-///
-/// let foo: ByteArray = #"00"
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(key: foo, value: "Aiken", compare: bytearray.compare)
-///     |> dict.get(key: foo)
+///     |> dict.insert(key: "a", value: "Aiken")
+///     |> dict.get(key: "a")
 ///
 ///  result == Some("Aiken")
 /// ```
-pub fn get(self: Dict<key, value>, key: key) -> Option<value> {
+pub fn get(self: Dict<key, value>, key: ByteArray) -> Option<value> {
   do_get(self.inner, key)
 }
 
-fn do_get(self: List<(key, value)>, key k: key) -> Option<value> {
+fn do_get(self: List<(ByteArray, value)>, key k: ByteArray) -> Option<value> {
   when self is {
     [] -> None
     [(k2, v), ..rest] ->
-      if k == k2 {
-        Some(v)
+      if builtin.less_than_equals_bytearray(k, k2) {
+        if k == k2 {
+          Some(v)
+        } else {
+          None
+        }
       } else {
         do_get(rest, k)
       }
@@ -532,43 +522,73 @@ test get_1() {
 test get_2() {
   let m =
     new()
-      |> insert(foo, "Aiken", bytearray.compare)
-      |> insert(bar, "awesome", bytearray.compare)
+      |> insert(foo, "Aiken")
+      |> insert(bar, "awesome")
   get(m, key: foo) == Some("Aiken")
 }
 
 test get_3() {
   let m =
     new()
-      |> insert(foo, "Aiken", bytearray.compare)
-      |> insert(bar, "awesome", bytearray.compare)
+      |> insert(foo, "Aiken")
+      |> insert(bar, "awesome")
   get(m, key: baz) == None
+}
+
+test get_4() {
+  let m =
+    new()
+      |> insert("aaa", "1")
+      |> insert("bbb", "2")
+      |> insert("ccc", "3")
+      |> insert("ddd", "4")
+      |> insert("eee", "5")
+      |> insert("fff", "6")
+      |> insert("ggg", "7")
+      |> insert("hhh", "8")
+      |> insert("iii", "9")
+      |> insert("jjj", "10")
+
+  get(m, "bcd") == None
+}
+
+test get_5() {
+  let m =
+    new()
+      |> insert("aaa", "1")
+      |> insert("bbb", "2")
+      |> insert("ccc", "3")
+      |> insert("ddd", "4")
+      |> insert("eee", "5")
+      |> insert("fff", "6")
+      |> insert("ggg", "7")
+      |> insert("hhh", "8")
+      |> insert("iii", "9")
+      |> insert("jjj", "10")
+
+  get(m, "kkk") == None
 }
 
 /// Check if a key exists in the dictionary.
 ///
 /// ```aiken
-/// use aiken/bytearray
-///
-/// let foo: ByteArray = #"00"
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(key: foo, value: "Aiken", compare: bytearray.compare)
-///     |> dict.has_key(foo)
+///     |> dict.insert(key: "a", value: "Aiken")
+///     |> dict.has_key("a")
 ///
 /// result == True
 /// ```
-pub fn has_key(self: Dict<key, value>, key k: key) -> Bool {
+pub fn has_key(self: Dict<key, value>, key k: ByteArray) -> Bool {
   do_has_key(self.inner, k)
 }
 
-fn do_has_key(self: List<(key, value)>, key k: key) -> Bool {
+fn do_has_key(self: List<(ByteArray, value)>, key k: ByteArray) -> Bool {
   when self is {
     [] -> False
     [(k2, _), ..rest] ->
-      if k == k2 {
-        True
+      if builtin.less_than_equals_bytearray(k, k2) {
+        k == k2
       } else {
         do_has_key(rest, k)
       }
@@ -582,7 +602,7 @@ test has_key_1() {
 test has_key_2() {
   has_key(
     new()
-      |> insert(foo, 14, bytearray.compare),
+      |> insert(foo, 14),
     foo,
   )
 }
@@ -590,7 +610,7 @@ test has_key_2() {
 test has_key_3() {
   !has_key(
     new()
-      |> insert(foo, 14, bytearray.compare),
+      |> insert(foo, 14),
     bar,
   )
 }
@@ -598,8 +618,8 @@ test has_key_3() {
 test has_key_4() {
   has_key(
     new()
-      |> insert(foo, 14, bytearray.compare)
-      |> insert(bar, 42, bytearray.compare),
+      |> insert(foo, 14)
+      |> insert(bar, 42),
     bar,
   )
 }
@@ -607,43 +627,39 @@ test has_key_4() {
 /// Insert a value in the dictionary at a given key. If the key already exists, its value is **overridden**. If you need ways to combine keys together, use (`insert_with`)[#insert_with].
 ///
 /// ```aiken
-/// use aiken/bytearray
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(key: "foo", value: 1, compare: bytearray.compare)
-///     |> dict.insert(key: "bar", value: 2, compare: bytearray.compare)
-///     |> dict.insert(key: "foo", value: 3, compare: bytearray.compare)
+///     |> dict.insert(key: "a", value: 1)
+///     |> dict.insert(key: "b", value: 2)
+///     |> dict.insert(key: "a", value: 3)
 ///     |> dict.to_list()
 ///
-/// result == [("bar", 2), ("foo", 3)]
+/// result == [("a", 3), ("b", 2)]
 /// ```
 pub fn insert(
   self: Dict<key, value>,
-  key k: key,
+  key k: ByteArray,
   value v: value,
-  compare: fn(key, key) -> Ordering,
 ) -> Dict<key, value> {
-  Dict { inner: do_insert(self.inner, k, v, compare) }
+  Dict { inner: do_insert(self.inner, k, v) }
 }
 
 fn do_insert(
-  self: List<(key, value)>,
-  key k: key,
+  self: List<(ByteArray, value)>,
+  key k: ByteArray,
   value v: value,
-  compare: fn(key, key) -> Ordering,
-) -> List<(key, value)> {
+) -> List<(ByteArray, value)> {
   when self is {
     [] ->
       [(k, v)]
     [(k2, v2), ..rest] ->
-      if compare(k, k2) == Less {
+      if builtin.less_than_bytearray(k, k2) {
         [(k, v), ..self]
       } else {
         if k == k2 {
           [(k, v), ..rest]
         } else {
-          [(k2, v2), ..do_insert(rest, k, v, compare)]
+          [(k2, v2), ..do_insert(rest, k, v)]
         }
       }
   }
@@ -652,61 +668,47 @@ fn do_insert(
 test insert_1() {
   let m1 =
     new()
-      |> insert(foo, 42, bytearray.compare)
+      |> insert(foo, 42)
   let m2 =
     new()
-      |> insert(foo, 14, bytearray.compare)
-  insert(m1, foo, 14, bytearray.compare) == m2
+      |> insert(foo, 14)
+  insert(m1, foo, 14) == m2
 }
 
 test insert_2() {
   let m1 =
     new()
-      |> insert(foo, 42, bytearray.compare)
+      |> insert(foo, 42)
   let m2 =
     new()
-      |> insert(bar, 14, bytearray.compare)
-  insert(m1, bar, 14, bytearray.compare) == insert(
-    m2,
-    foo,
-    42,
-    bytearray.compare,
-  )
+      |> insert(bar, 14)
+  insert(m1, bar, 14) == insert(m2, foo, 42)
 }
 
 /// Insert a value in the dictionary at a given key. When the key already exist, the provided
 /// merge function is called.
 ///
 /// ```aiken
-/// use aiken/bytearray
-///
 /// let sum =
 ///   fn (_k, a, b) { Some(a + b) }
 ///
 /// let result =
 ///   dict.new()
-///     |> dict.insert_with(key: "foo", value: 1, with: sum, compare: bytearray.compare)
-///     |> dict.insert_with(key: "bar", value: 2, with: sum, compare: bytearray.compare)
-///     |> dict.insert_with(key: "foo", value: 3, with: sum, compare: bytearray.compare)
+///     |> dict.insert_with(key: "a", value: 1, with: sum)
+///     |> dict.insert_with(key: "b", value: 2, with: sum)
+///     |> dict.insert_with(key: "a", value: 3, with: sum)
 ///     |> dict.to_list()
 ///
-/// result == [("bar", 2), ("foo", 4)]
+/// result == [("a", 4), ("b", 2)]
 /// ```
 pub fn insert_with(
   self: Dict<key, value>,
-  key k: key,
+  key k: ByteArray,
   value v: value,
-  with: fn(key, value, value) -> Option<value>,
-  compare: fn(key, key) -> Ordering,
+  with: fn(ByteArray, value, value) -> Option<value>,
 ) -> Dict<key, value> {
   Dict {
-    inner: do_insert_with(
-      self.inner,
-      k,
-      v,
-      fn(k, v1, v2) { with(k, v2, v1) },
-      compare,
-    ),
+    inner: do_insert_with(self.inner, k, v, fn(k, v1, v2) { with(k, v2, v1) }),
   }
 }
 
@@ -716,8 +718,8 @@ test insert_with_1() {
 
   let result =
     new()
-      |> insert_with(key: "foo", value: 1, with: sum, compare: bytearray.compare)
-      |> insert_with(key: "bar", value: 2, with: sum, compare: bytearray.compare)
+      |> insert_with(key: "foo", value: 1, with: sum)
+      |> insert_with(key: "bar", value: 2, with: sum)
       |> to_list()
 
   result == [("bar", 2), ("foo", 1)]
@@ -729,9 +731,9 @@ test insert_with_2() {
 
   let result =
     new()
-      |> insert_with(key: "foo", value: 1, with: sum, compare: bytearray.compare)
-      |> insert_with(key: "bar", value: 2, with: sum, compare: bytearray.compare)
-      |> insert_with(key: "foo", value: 3, with: sum, compare: bytearray.compare)
+      |> insert_with(key: "foo", value: 1, with: sum)
+      |> insert_with(key: "bar", value: 2, with: sum)
+      |> insert_with(key: "foo", value: 3, with: sum)
       |> to_list()
 
   result == [("bar", 2), ("foo", 4)]
@@ -749,10 +751,10 @@ test insert_with_3() {
 
   let result =
     new()
-      |> insert_with(key: "foo", value: 1, with: with, compare: bytearray.compare)
-      |> insert_with(key: "bar", value: 2, with: with, compare: bytearray.compare)
-      |> insert_with(key: "foo", value: 3, with: with, compare: bytearray.compare)
-      |> insert_with(key: "bar", value: 4, with: with, compare: bytearray.compare)
+      |> insert_with(key: "foo", value: 1, with: with)
+      |> insert_with(key: "bar", value: 2, with: with)
+      |> insert_with(key: "foo", value: 3, with: with)
+      |> insert_with(key: "bar", value: 4, with: with)
       |> to_list()
 
   result == [("foo", 1)]
@@ -776,25 +778,20 @@ test is_empty_1() {
 /// Extract all the keys present in a given `Dict`.
 ///
 /// ```aiken
-/// use aiken/bytearray
-///
-/// let foo: ByteArray = #"00"
-/// let bar: ByteArray = #"11"
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(foo, 14, bytearray.compare)
-///     |> dict.insert(bar, 42, bytearray.compare)
-///     |> dict.insert(foo, 1337, bytearray.compare)
+///     |> dict.insert("a", 14)
+///     |> dict.insert("b", 42)
+///     |> dict.insert("a", 1337)
 ///     |> dict.keys()
 ///
-/// result == [foo, bar]
+/// result == ["a", "b"]
 /// ```
-pub fn keys(self: Dict<key, value>) -> List<key> {
+pub fn keys(self: Dict<key, value>) -> List<ByteArray> {
   do_keys(self.inner)
 }
 
-fn do_keys(self: List<(key, value)>) -> List<key> {
+fn do_keys(self: List<(ByteArray, value)>) -> List<ByteArray> {
   when self is {
     [] ->
       []
@@ -810,31 +807,32 @@ test keys_1() {
 test keys_2() {
   keys(
     new()
-      |> insert(foo, 0, bytearray.compare)
-      |> insert(bar, 0, bytearray.compare),
+      |> insert(foo, 0)
+      |> insert(bar, 0),
   ) == [bar, foo]
 }
 
 /// Apply a function to all key-value pairs in a map.
 ///
 /// ```aiken
-/// use aiken/int
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(1, 100, int.compare)
-///     |> dict.insert(2, 200, int.compare)
-///     |> dict.insert(3, 300, int.compare)
+///     |> dict.insert("a", 100)
+///     |> dict.insert("b", 200)
+///     |> dict.insert("c", 300)
 ///     |> dict.map(fn(_k, v) { v * 2 })
 ///     |> dict.to_list()
 ///
-///  result == [(1, 200), (2, 400), (3, 600)]
+///  result == [("a", 200), ("b", 400), ("c", 600)]
 /// ```
-pub fn map(self: Dict<key, a>, with: fn(key, a) -> b) -> Dict<key, b> {
+pub fn map(self: Dict<key, a>, with: fn(ByteArray, a) -> b) -> Dict<key, b> {
   Dict { inner: do_map(self.inner, with) }
 }
 
-fn do_map(self: List<(key, a)>, with: fn(key, a) -> b) -> List<(key, b)> {
+fn do_map(
+  self: List<(ByteArray, a)>,
+  with: fn(ByteArray, a) -> b,
+) -> List<(ByteArray, b)> {
   when self is {
     [] ->
       []
@@ -860,18 +858,16 @@ test map_2() {
 /// Get the inner list holding the dictionary data.
 ///
 /// ```aiken
-/// use aiken/int
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(1, 100, int.compare)
-///     |> dict.insert(2, 200, int.compare)
-///     |> dict.insert(3, 300, int.compare)
+///     |> dict.insert("a", 100)
+///     |> dict.insert("b", 200)
+///     |> dict.insert("c", 300)
 ///     |> dict.to_list()
 ///
-/// result == [(1, 100), (2, 200), (3, 300)]
+/// result == [("a", 100), ("b", 200), ("c", 300)]
 /// ```
-pub fn to_list(self: Dict<key, value>) -> List<(key, value)> {
+pub fn to_list(self: Dict<key, value>) -> List<(ByteArray, value)> {
   self.inner
 }
 
@@ -886,13 +882,11 @@ test to_list_2() {
 /// Return the number of key-value pairs in the dictionary.
 ///
 /// ```aiken
-/// use aiken/int
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(1, 100, int.compare)
-///     |> dict.insert(2, 200, int.compare)
-///     |> dict.insert(3, 300, int.compare)
+///     |> dict.insert("a", 100)
+///     |> dict.insert("b", 200)
+///     |> dict.insert("c", 300)
 ///     |> dict.size()
 ///
 /// result == 3
@@ -915,15 +909,15 @@ test size_1() {
 test size_2() {
   size(
     new()
-      |> insert(foo, 14, bytearray.compare),
+      |> insert(foo, 14),
   ) == 1
 }
 
 test size_3() {
   size(
     new()
-      |> insert(foo, 14, bytearray.compare)
-      |> insert(bar, 42, bytearray.compare),
+      |> insert(foo, 14)
+      |> insert(bar, 42),
   ) == 2
 }
 
@@ -931,69 +925,59 @@ test size_3() {
 /// right dictionary, values from the left are preferred (i.e. left-biaised).
 ///
 /// ```aiken
-/// use aiken/int
-///
-/// let left_dict = dict.from_list([(1, 100), (2, 200)], int.compare)
-/// let right_dict = dict.from_list([(1, 150), (3, 300)], int.compare)
+/// let left_dict = dict.from_list([("a", 100), ("b", 200)])
+/// let right_dict = dict.from_list([("a", 150), ("c", 300)])
 ///
 /// let result =
-///   dict.union(left_dict, right_dict, int.compare) |> dict.to_list()
+///   dict.union(left_dict, right_dict) |> dict.to_list()
 ///
-/// result == [(1, 100), (2, 200), (3, 300)]
+/// result == [("a", 100), ("b", 200), ("c", 300)]
 /// ```
 pub fn union(
   left: Dict<key, value>,
   right: Dict<key, value>,
-  compare: fn(key, key) -> Ordering,
 ) -> Dict<key, value> {
-  Dict { inner: do_union(left.inner, right.inner, compare) }
+  Dict { inner: do_union(left.inner, right.inner) }
 }
 
 fn do_union(
-  left: List<(key, value)>,
-  right: List<(key, value)>,
-  compare: fn(key, key) -> Ordering,
-) -> List<(key, value)> {
+  left: List<(ByteArray, value)>,
+  right: List<(ByteArray, value)>,
+) -> List<(ByteArray, value)> {
   when left is {
     [] -> right
-    [(k, v), ..rest] -> do_union(rest, do_insert(right, k, v, compare), compare)
+    [(k, v), ..rest] -> do_union(rest, do_insert(right, k, v))
   }
 }
 
 test union_1() {
-  union(fixture_1(), new(), bytearray.compare) == fixture_1()
+  union(fixture_1(), new()) == fixture_1()
 }
 
 test union_2() {
-  union(new(), fixture_1(), bytearray.compare) == fixture_1()
+  union(new(), fixture_1()) == fixture_1()
 }
 
 test union_3() {
   let left =
     new()
-      |> insert(foo, 14, bytearray.compare)
+      |> insert(foo, 14)
   let right =
     new()
-      |> insert(bar, 42, bytearray.compare)
-      |> insert(baz, 1337, bytearray.compare)
-  union(left, right, bytearray.compare) == from_list(
-    [(foo, 14), (baz, 1337), (bar, 42)],
-    bytearray.compare,
-  )
+      |> insert(bar, 42)
+      |> insert(baz, 1337)
+  union(left, right) == from_list([(foo, 14), (baz, 1337), (bar, 42)])
 }
 
 test union_4() {
   let left =
     new()
-      |> insert(foo, 14, bytearray.compare)
+      |> insert(foo, 14)
   let right =
     new()
-      |> insert(bar, 42, bytearray.compare)
-      |> insert(foo, 1337, bytearray.compare)
-  union(left, right, bytearray.compare) == from_list(
-    [(foo, 14), (bar, 42)],
-    bytearray.compare,
-  )
+      |> insert(bar, 42)
+      |> insert(foo, 1337)
+  union(left, right) == from_list([(foo, 14), (bar, 42)])
 }
 
 /// Like [`union`](#union) but allows specifying the behavior to adopt when a key is present
@@ -1003,61 +987,50 @@ test union_4() {
 /// When passing `None`, the value is removed and not present in the union.
 ///
 /// ```aiken
-/// use aiken/int
-///
-/// let left_dict = dict.from_list([(1, 100), (2, 200)], int.compare)
-/// let right_dict = dict.from_list([(1, 150), (3, 300)], int.compare)
+/// let left_dict = dict.from_list([("a", 100), ("b", 200)])
+/// let right_dict = dict.from_list([("a", 150), ("c", 300)])
 ///
 /// let result =
 ///   dict.union_with(
 ///     left_dict,
 ///     right_dict,
 ///     fn(_k, v1, v2) { Some(v1 + v2) },
-///     int.compare,
 ///   )
 ///     |> dict.to_list()
 ///
-/// result == [(1, 250), (2, 200), (3, 300)]
+/// result == [("a", 250), ("b", 200), ("c", 300)]
 /// ```
 pub fn union_with(
   left: Dict<key, value>,
   right: Dict<key, value>,
-  with: fn(key, value, value) -> Option<value>,
-  compare: fn(key, key) -> Ordering,
+  with: fn(ByteArray, value, value) -> Option<value>,
 ) -> Dict<key, value> {
-  Dict { inner: do_union_with(left.inner, right.inner, with, compare) }
+  Dict { inner: do_union_with(left.inner, right.inner, with) }
 }
 
 fn do_union_with(
-  left: List<(key, value)>,
-  right: List<(key, value)>,
-  with: fn(key, value, value) -> Option<value>,
-  compare: fn(key, key) -> Ordering,
-) -> List<(key, value)> {
+  left: List<(ByteArray, value)>,
+  right: List<(ByteArray, value)>,
+  with: fn(ByteArray, value, value) -> Option<value>,
+) -> List<(ByteArray, value)> {
   when left is {
     [] -> right
     [(k, v), ..rest] ->
-      do_union_with(
-        rest,
-        do_insert_with(right, k, v, with, compare),
-        with,
-        compare,
-      )
+      do_union_with(rest, do_insert_with(right, k, v, with), with)
   }
 }
 
 fn do_insert_with(
-  self: List<(key, value)>,
-  key k: key,
+  self: List<(ByteArray, value)>,
+  key k: ByteArray,
   value v: value,
-  with: fn(key, value, value) -> Option<value>,
-  compare: fn(key, key) -> Ordering,
-) -> List<(key, value)> {
+  with: fn(ByteArray, value, value) -> Option<value>,
+) -> List<(ByteArray, value)> {
   when self is {
     [] ->
       [(k, v)]
     [(k2, v2), ..rest] ->
-      if compare(k, k2) == Less {
+      if builtin.less_than_bytearray(k, k2) {
         [(k, v), ..self]
       } else {
         if k == k2 {
@@ -1067,7 +1040,7 @@ fn do_insert_with(
             None -> rest
           }
         } else {
-          [(k2, v2), ..do_insert_with(rest, k, v, with, compare)]
+          [(k2, v2), ..do_insert_with(rest, k, v, with)]
         }
       }
   }
@@ -1076,37 +1049,26 @@ fn do_insert_with(
 test union_with_1() {
   let left =
     new()
-      |> insert(foo, 14, bytearray.compare)
+      |> insert(foo, 14)
 
   let right =
     new()
-      |> insert(bar, 42, bytearray.compare)
-      |> insert(foo, 1337, bytearray.compare)
+      |> insert(bar, 42)
+      |> insert(foo, 1337)
 
-  let result =
-    union_with(
-      left,
-      right,
-      with: fn(_, l, r) { Some(l + r) },
-      compare: bytearray.compare,
-    )
+  let result = union_with(left, right, with: fn(_, l, r) { Some(l + r) })
 
-  result == from_list([(foo, 1351), (bar, 42)], bytearray.compare)
+  result == from_list([(foo, 1351), (bar, 42)])
 }
 
 /// Extract all the values present in a given `Dict`.
 ///
 /// ```aiken
-/// use aiken/bytearray
-///
-/// let foo: ByteArray = #"00"
-/// let bar: ByteArray = #"11"
-///
 /// let result =
 ///   dict.new()
-///     |> dict.insert(foo, 14, bytearray.compare)
-///     |> dict.insert(bar, 42, bytearray.compare)
-///     |> dict.insert(foo, 1337, bytearray.compare)
+///     |> dict.insert("a", 14)
+///     |> dict.insert("b", 42)
+///     |> dict.insert("c", 1337)
 ///     |> dict.values()
 ///
 /// result == [1337, 42]
@@ -1131,7 +1093,7 @@ test values_1() {
 test values_2() {
   values(
     new()
-      |> insert(foo, 3, bytearray.compare)
-      |> insert(bar, 4, bytearray.compare),
+      |> insert(foo, 3)
+      |> insert(bar, 4),
   ) == [4, 3]
 }

--- a/lib/aiken/dict.ak
+++ b/lib/aiken/dict.ak
@@ -20,7 +20,7 @@ use aiken/builtin
 ///   Dict<PolicyId, Dict<AssetName, Int>>
 /// ```
 pub opaque type Dict<key, value> {
-  inner: Map<ByteArray, value>,
+  inner: AList<ByteArray, value>,
 }
 
 /// Create a new empty Dict
@@ -60,9 +60,9 @@ pub fn delete(self: Dict<key, value>, key: ByteArray) -> Dict<key, value> {
 }
 
 fn do_delete(
-  self: Map<ByteArray, value>,
+  self: AList<ByteArray, value>,
   key k: ByteArray,
-) -> Map<ByteArray, value> {
+) -> AList<ByteArray, value> {
   when self is {
     [] ->
       []
@@ -151,9 +151,9 @@ pub fn filter(
 }
 
 fn do_filter(
-  self: Map<ByteArray, value>,
+  self: AList<ByteArray, value>,
   with: fn(ByteArray, value) -> Bool,
-) -> Map<ByteArray, value> {
+) -> AList<ByteArray, value> {
   when self is {
     [] ->
       []
@@ -200,7 +200,7 @@ pub fn find(self: Dict<key, value>, value v: value) -> Option<ByteArray> {
   do_find(self.inner, v)
 }
 
-fn do_find(self: Map<ByteArray, value>, value v: value) -> Option<ByteArray> {
+fn do_find(self: AList<ByteArray, value>, value v: value) -> Option<ByteArray> {
   when self is {
     [] -> None
     [Pair(k2, v2), ..rest] ->
@@ -264,7 +264,7 @@ pub fn foldr(
 }
 
 fn do_foldr(
-  self: Map<ByteArray, value>,
+  self: AList<ByteArray, value>,
   zero: result,
   with: fn(ByteArray, value, result) -> result,
 ) -> result {
@@ -304,7 +304,7 @@ pub fn foldl(
 }
 
 fn do_foldl(
-  self: Map<ByteArray, value>,
+  self: AList<ByteArray, value>,
   zero: result,
   with: fn(ByteArray, value, result) -> result,
 ) -> result {
@@ -334,11 +334,11 @@ test fold_2() {
 ///
 /// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
-pub fn from_map(self: Map<ByteArray, value>) -> Dict<key, value> {
+pub fn from_map(self: AList<ByteArray, value>) -> Dict<key, value> {
   Dict { inner: do_from_map(self) }
 }
 
-fn do_from_map(xs: Map<ByteArray, value>) -> Map<ByteArray, value> {
+fn do_from_map(xs: AList<ByteArray, value>) -> AList<ByteArray, value> {
   when xs is {
     [] ->
       []
@@ -408,12 +408,12 @@ test bench_from_map() {
 /// which has taken care of maintaining interval invariants. This function still
 /// performs a sanity check on all keys to avoid silly mistakes. It is, however,
 /// considerably faster than ['from_map'](from_map)
-pub fn from_ascending_map(xs: Map<ByteArray, value>) -> Dict<key, value> {
+pub fn from_ascending_map(xs: AList<ByteArray, value>) -> Dict<key, value> {
   let Void = check_ascending_map(xs)
   Dict { inner: xs }
 }
 
-fn check_ascending_map(xs: Map<ByteArray, value>) {
+fn check_ascending_map(xs: AList<ByteArray, value>) {
   when xs is {
     [] -> Void
     [_] -> Void
@@ -427,7 +427,7 @@ fn check_ascending_map(xs: Map<ByteArray, value>) {
 }
 
 pub fn from_ascending_map_with(
-  xs: Map<ByteArray, value>,
+  xs: AList<ByteArray, value>,
   value_predicate: fn(value) -> Bool,
 ) -> Dict<key, value> {
   let Void = check_ascending_map_with(xs, value_predicate)
@@ -435,7 +435,7 @@ pub fn from_ascending_map_with(
 }
 
 fn check_ascending_map_with(
-  xs: Map<ByteArray, value>,
+  xs: AList<ByteArray, value>,
   value_predicate: fn(value) -> Bool,
 ) {
   when xs is {
@@ -499,7 +499,7 @@ pub fn get(self: Dict<key, value>, key: ByteArray) -> Option<value> {
   do_get(self.inner, key)
 }
 
-fn do_get(self: Map<ByteArray, value>, key k: ByteArray) -> Option<value> {
+fn do_get(self: AList<ByteArray, value>, key k: ByteArray) -> Option<value> {
   when self is {
     [] -> None
     [Pair(k2, v), ..rest] ->
@@ -583,7 +583,7 @@ pub fn has_key(self: Dict<key, value>, key k: ByteArray) -> Bool {
   do_has_key(self.inner, k)
 }
 
-fn do_has_key(self: Map<ByteArray, value>, key k: ByteArray) -> Bool {
+fn do_has_key(self: AList<ByteArray, value>, key k: ByteArray) -> Bool {
   when self is {
     [] -> False
     [Pair(k2, _), ..rest] ->
@@ -645,10 +645,10 @@ pub fn insert(
 }
 
 fn do_insert(
-  self: Map<ByteArray, value>,
+  self: AList<ByteArray, value>,
   key k: ByteArray,
   value v: value,
-) -> Map<ByteArray, value> {
+) -> AList<ByteArray, value> {
   when self is {
     [] ->
       [Pair(k, v)]
@@ -792,7 +792,7 @@ pub fn keys(self: Dict<key, value>) -> List<ByteArray> {
   do_keys(self.inner)
 }
 
-fn do_keys(self: Map<ByteArray, value>) -> List<ByteArray> {
+fn do_keys(self: AList<ByteArray, value>) -> List<ByteArray> {
   when self is {
     [] ->
       []
@@ -831,9 +831,9 @@ pub fn map(self: Dict<key, a>, with: fn(ByteArray, a) -> b) -> Dict<key, b> {
 }
 
 fn do_map(
-  self: Map<ByteArray, a>,
+  self: AList<ByteArray, a>,
   with: fn(ByteArray, a) -> b,
-) -> Map<ByteArray, b> {
+) -> AList<ByteArray, b> {
   when self is {
     [] ->
       []
@@ -868,7 +868,7 @@ test map_2() {
 ///
 /// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
-pub fn to_map(self: Dict<key, value>) -> Map<ByteArray, value> {
+pub fn to_map(self: Dict<key, value>) -> AList<ByteArray, value> {
   self.inner
 }
 
@@ -896,7 +896,7 @@ pub fn size(self: Dict<key, value>) -> Int {
   do_size(self.inner)
 }
 
-fn do_size(self: Map<key, value>) -> Int {
+fn do_size(self: AList<key, value>) -> Int {
   when self is {
     [] -> 0
     [_, ..rest] -> 1 + do_size(rest)
@@ -942,9 +942,9 @@ pub fn union(
 }
 
 fn do_union(
-  left: Map<ByteArray, value>,
-  right: Map<ByteArray, value>,
-) -> Map<ByteArray, value> {
+  left: AList<ByteArray, value>,
+  right: AList<ByteArray, value>,
+) -> AList<ByteArray, value> {
   when left is {
     [] -> right
     [Pair(k, v), ..rest] -> do_union(rest, do_insert(right, k, v))
@@ -1012,10 +1012,10 @@ pub fn union_with(
 }
 
 fn do_union_with(
-  left: Map<ByteArray, value>,
-  right: Map<ByteArray, value>,
+  left: AList<ByteArray, value>,
+  right: AList<ByteArray, value>,
   with: fn(ByteArray, value, value) -> Option<value>,
-) -> Map<ByteArray, value> {
+) -> AList<ByteArray, value> {
   when left is {
     [] -> right
     [Pair(k, v), ..rest] ->
@@ -1024,11 +1024,11 @@ fn do_union_with(
 }
 
 fn do_insert_with(
-  self: Map<ByteArray, value>,
+  self: AList<ByteArray, value>,
   key k: ByteArray,
   value v: value,
   with: fn(ByteArray, value, value) -> Option<value>,
-) -> Map<ByteArray, value> {
+) -> AList<ByteArray, value> {
   when self is {
     [] ->
       [Pair(k, v)]
@@ -1080,7 +1080,7 @@ pub fn values(self: Dict<key, value>) -> List<value> {
   do_values(self.inner)
 }
 
-fn do_values(self: Map<key, value>) -> List<value> {
+fn do_values(self: AList<key, value>) -> List<value> {
   when self is {
     [] ->
       []

--- a/lib/aiken/dict.ak
+++ b/lib/aiken/dict.ak
@@ -326,47 +326,47 @@ test fold_2() {
 /// multiple times, the first occurrence prevails.
 ///
 /// ```aiken
-/// let map = [Pair("a", 100), Pair("c", 300), Pair("b", 200)]
+/// let alist = [Pair("a", 100), Pair("c", 300), Pair("b", 200)]
 ///
 /// let result =
-///   dict.from_map(map)
+///   dict.from_alist(alist)
 ///     |> dict.to_alist()
 ///
 /// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
-pub fn from_map(self: AList<ByteArray, value>) -> Dict<key, value> {
-  Dict { inner: do_from_map(self) }
+pub fn from_alist(self: AList<ByteArray, value>) -> Dict<key, value> {
+  Dict { inner: do_from_alist(self) }
 }
 
-fn do_from_map(xs: AList<ByteArray, value>) -> AList<ByteArray, value> {
+fn do_from_alist(xs: AList<ByteArray, value>) -> AList<ByteArray, value> {
   when xs is {
     [] ->
       []
-    [Pair(k, v), ..rest] -> do_insert(do_from_map(rest), k, v)
+    [Pair(k, v), ..rest] -> do_insert(do_from_alist(rest), k, v)
   }
 }
 
-test from_map_1() {
-  from_map([]) == new()
+test from_alist_1() {
+  from_alist([]) == new()
 }
 
-test from_map_2() {
-  from_map([Pair(foo, 42), Pair(bar, 14)]) == from_map(
+test from_alist_2() {
+  from_alist([Pair(foo, 42), Pair(bar, 14)]) == from_alist(
     [Pair(bar, 14), Pair(foo, 42)],
   )
 }
 
-test from_map_3() {
-  from_map([Pair(foo, 42), Pair(bar, 14)]) == fixture_1()
+test from_alist_3() {
+  from_alist([Pair(foo, 42), Pair(bar, 14)]) == fixture_1()
 }
 
-test from_map_4() {
-  from_map([Pair(foo, 42), Pair(bar, 14), Pair(foo, 1337)]) == fixture_1()
+test from_alist_4() {
+  from_alist([Pair(foo, 42), Pair(bar, 14), Pair(foo, 1337)]) == fixture_1()
 }
 
-test bench_from_map() {
+test bench_from_alist() {
   let dict =
-    from_map(
+    from_alist(
       [
         Pair("bbba", 8),
         Pair("bbab", 12),
@@ -390,15 +390,15 @@ test bench_from_map() {
   size(dict) == 16
 }
 
-/// Like ['from_map'](from_map), but from an already sorted list by ascending
+/// Like ['from_alist'](from_alist), but from an already sorted list by ascending
 /// keys. This function fails (i.e. halt the program execution) if the list isn't
 /// sorted.
 ///
 /// ```aiken
-/// let map = [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
+/// let alist = [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 ///
 /// let result =
-///   dict.from_ascending_map(map)
+///   dict.from_ascending_alist(alist)
 ///     |> dict.to_alist()
 ///
 /// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
@@ -407,34 +407,34 @@ test bench_from_map() {
 /// This is meant to be used to turn a list constructed off-chain into a `Dict`
 /// which has taken care of maintaining interval invariants. This function still
 /// performs a sanity check on all keys to avoid silly mistakes. It is, however,
-/// considerably faster than ['from_map'](from_map)
-pub fn from_ascending_map(xs: AList<ByteArray, value>) -> Dict<key, value> {
-  let Void = check_ascending_map(xs)
+/// considerably faster than ['from_alist'](from_alist)
+pub fn from_ascending_alist(xs: AList<ByteArray, value>) -> Dict<key, value> {
+  let Void = check_ascending_alist(xs)
   Dict { inner: xs }
 }
 
-fn check_ascending_map(xs: AList<ByteArray, value>) {
+fn check_ascending_alist(xs: AList<ByteArray, value>) {
   when xs is {
     [] -> Void
     [_] -> Void
     [Pair(x0, _), Pair(x1, _) as e, ..rest] ->
       if builtin.less_than_bytearray(x0, x1) {
-        check_ascending_map([e, ..rest])
+        check_ascending_alist([e, ..rest])
       } else {
         fail @"keys in associative list aren't in ascending order"
       }
   }
 }
 
-pub fn from_ascending_map_with(
+pub fn from_ascending_alist_with(
   xs: AList<ByteArray, value>,
   value_predicate: fn(value) -> Bool,
 ) -> Dict<key, value> {
-  let Void = check_ascending_map_with(xs, value_predicate)
+  let Void = check_ascending_alist_with(xs, value_predicate)
   Dict { inner: xs }
 }
 
-fn check_ascending_map_with(
+fn check_ascending_alist_with(
   xs: AList<ByteArray, value>,
   value_predicate: fn(value) -> Bool,
 ) {
@@ -449,7 +449,7 @@ fn check_ascending_map_with(
     [Pair(x0, v0), Pair(x1, _) as e, ..rest] ->
       if builtin.less_than_bytearray(x0, x1) {
         if value_predicate(v0) {
-          check_ascending_map_with([e, ..rest], value_predicate)
+          check_ascending_alist_with([e, ..rest], value_predicate)
         } else {
           fail @"value doesn't satisfy predicate"
         }
@@ -459,9 +459,9 @@ fn check_ascending_map_with(
   }
 }
 
-test bench_from_ascending_map() {
+test bench_from_ascending_alist() {
   let dict =
-    from_ascending_map(
+    from_ascending_alist(
       [
         Pair("aaaa", 1),
         Pair("aaab", 9),
@@ -813,7 +813,7 @@ test keys_2() {
   ) == [bar, foo]
 }
 
-/// Apply a function to all key-value pairs in a map.
+/// Apply a function to all key-value pairs in a Dict.
 ///
 /// ```aiken
 /// let result =
@@ -967,7 +967,7 @@ test union_3() {
     new()
       |> insert(bar, 42)
       |> insert(baz, 1337)
-  union(left, right) == from_map(
+  union(left, right) == from_alist(
     [Pair(foo, 14), Pair(baz, 1337), Pair(bar, 42)],
   )
 }
@@ -980,7 +980,7 @@ test union_4() {
     new()
       |> insert(bar, 42)
       |> insert(foo, 1337)
-  union(left, right) == from_map([Pair(foo, 14), Pair(bar, 42)])
+  union(left, right) == from_alist([Pair(foo, 14), Pair(bar, 42)])
 }
 
 /// Like [`union`](#union) but allows specifying the behavior to adopt when a key is present
@@ -990,8 +990,8 @@ test union_4() {
 /// When passing `None`, the value is removed and not present in the union.
 ///
 /// ```aiken
-/// let left_dict = dict.from_map([Pair("a", 100), Pair("b", 200)])
-/// let right_dict = dict.from_map([Pair("a", 150), Pair("c", 300)])
+/// let left_dict = dict.from_alist([Pair("a", 100), Pair("b", 200)])
+/// let right_dict = dict.from_alist([Pair("a", 150), Pair("c", 300)])
 ///
 /// let result =
 ///   dict.union_with(
@@ -1061,7 +1061,7 @@ test union_with_1() {
 
   let result = union_with(left, right, with: fn(_, l, r) { Some(l + r) })
 
-  result == from_map([Pair(foo, 1351), Pair(bar, 42)])
+  result == from_alist([Pair(foo, 1351), Pair(bar, 42)])
 }
 
 /// Extract all the values present in a given `Dict`.

--- a/lib/aiken/dict.ak
+++ b/lib/aiken/dict.ak
@@ -25,7 +25,7 @@ pub opaque type Dict<key, value> {
 
 /// Create a new empty Dict
 /// ```aiken
-/// dict.to_map(dict.new()) == []
+/// dict.to_alist(dict.new()) == []
 /// ```
 pub fn new() -> Dict<key, value> {
   Dict { inner: [] }
@@ -51,7 +51,7 @@ fn fixture_1() {
 ///     |> dict.insert(key: "a", value: 100)
 ///     |> dict.insert(key: "b", value: 200)
 ///     |> dict.delete(key: "a")
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 /// result == [Pair("b", 200)]
 /// ```
@@ -139,7 +139,7 @@ test delete_6() {
 ///     |> dict.insert(key: "b", value: 200)
 ///     |> dict.insert(key: "c", value: 300)
 ///     |> dict.filter(fn(k, _v) { k != "a" })
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 /// result == [Pair("b", 200), Pair("c", 300)]
 /// ```
@@ -330,7 +330,7 @@ test fold_2() {
 ///
 /// let result =
 ///   dict.from_map(map)
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 /// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
@@ -399,7 +399,7 @@ test bench_from_map() {
 ///
 /// let result =
 ///   dict.from_ascending_map(map)
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 /// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
@@ -632,7 +632,7 @@ test has_key_4() {
 ///     |> dict.insert(key: "a", value: 1)
 ///     |> dict.insert(key: "b", value: 2)
 ///     |> dict.insert(key: "a", value: 3)
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 /// result == [Pair("a", 3), Pair("b", 2)]
 /// ```
@@ -698,7 +698,7 @@ test insert_2() {
 ///     |> dict.insert_with(key: "a", value: 1, with: sum)
 ///     |> dict.insert_with(key: "b", value: 2, with: sum)
 ///     |> dict.insert_with(key: "a", value: 3, with: sum)
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 /// result == [Pair("a", 4), Pair("b", 2)]
 /// ```
@@ -721,7 +721,7 @@ test insert_with_1() {
     new()
       |> insert_with(key: "foo", value: 1, with: sum)
       |> insert_with(key: "bar", value: 2, with: sum)
-      |> to_map()
+      |> to_alist()
 
   result == [Pair("bar", 2), Pair("foo", 1)]
 }
@@ -735,7 +735,7 @@ test insert_with_2() {
       |> insert_with(key: "foo", value: 1, with: sum)
       |> insert_with(key: "bar", value: 2, with: sum)
       |> insert_with(key: "foo", value: 3, with: sum)
-      |> to_map()
+      |> to_alist()
 
   result == [Pair("bar", 2), Pair("foo", 4)]
 }
@@ -756,7 +756,7 @@ test insert_with_3() {
       |> insert_with(key: "bar", value: 2, with: with)
       |> insert_with(key: "foo", value: 3, with: with)
       |> insert_with(key: "bar", value: 4, with: with)
-      |> to_map()
+      |> to_alist()
 
   result == [Pair("foo", 1)]
 }
@@ -822,7 +822,7 @@ test keys_2() {
 ///     |> dict.insert("b", 200)
 ///     |> dict.insert("c", 300)
 ///     |> dict.map(fn(_k, v) { v * 2 })
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 ///  result == [Pair("a", 200), Pair("b", 400), Pair("c", 600)]
 /// ```
@@ -864,20 +864,20 @@ test map_2() {
 ///     |> dict.insert("a", 100)
 ///     |> dict.insert("b", 200)
 ///     |> dict.insert("c", 300)
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 /// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
-pub fn to_map(self: Dict<key, value>) -> AList<ByteArray, value> {
+pub fn to_alist(self: Dict<key, value>) -> AList<ByteArray, value> {
   self.inner
 }
 
-test to_map_1() {
-  to_map(new()) == []
+test to_alist_1() {
+  to_alist(new()) == []
 }
 
-test to_map_2() {
-  to_map(fixture_1()) == [Pair(bar, 14), Pair(foo, 42)]
+test to_alist_2() {
+  to_alist(fixture_1()) == [Pair(bar, 14), Pair(foo, 42)]
 }
 
 /// Return the number of key-value pairs in the dictionary.
@@ -930,7 +930,7 @@ test size_3() {
 /// let right_dict = dict.from_list([Pair("a", 150), Pair("c", 300)])
 ///
 /// let result =
-///   dict.union(left_dict, right_dict) |> dict.to_map()
+///   dict.union(left_dict, right_dict) |> dict.to_alist()
 ///
 /// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
@@ -999,7 +999,7 @@ test union_4() {
 ///     right_dict,
 ///     fn(_k, v1, v2) { Some(v1 + v2) },
 ///   )
-///     |> dict.to_map()
+///     |> dict.to_alist()
 ///
 /// result == [Pair("a", 250), Pair("b", 200), Pair("c", 300)]
 /// ```

--- a/lib/aiken/dict.ak
+++ b/lib/aiken/dict.ak
@@ -20,12 +20,12 @@ use aiken/builtin
 ///   Dict<PolicyId, Dict<AssetName, Int>>
 /// ```
 pub opaque type Dict<key, value> {
-  inner: List<(ByteArray, value)>,
+  inner: Map<ByteArray, value>,
 }
 
 /// Create a new map
 /// ```aiken
-/// dict.to_list(dict.new()) == []
+/// dict.to_map(dict.new()) == []
 /// ```
 pub fn new() -> Dict<key, value> {
   Dict { inner: [] }
@@ -51,22 +51,22 @@ fn fixture_1() {
 ///     |> dict.insert(key: "a", value: 100)
 ///     |> dict.insert(key: "b", value: 200)
 ///     |> dict.delete(key: "a")
-///     |> dict.to_list()
+///     |> dict.to_map()
 ///
-/// result == [("b", 200)]
+/// result == [Pair("b", 200)]
 /// ```
 pub fn delete(self: Dict<key, value>, key: ByteArray) -> Dict<key, value> {
   Dict { inner: do_delete(self.inner, key) }
 }
 
 fn do_delete(
-  self: List<(ByteArray, value)>,
+  self: Map<ByteArray, value>,
   key k: ByteArray,
-) -> List<(ByteArray, value)> {
+) -> Map<ByteArray, value> {
   when self is {
     [] ->
       []
-    [(k2, v2), ..rest] ->
+    [Pair(k2, v2), ..rest] ->
       if builtin.less_than_equals_bytearray(k, k2) {
         if k == k2 {
           rest
@@ -74,7 +74,7 @@ fn do_delete(
           self
         }
       } else {
-        [(k2, v2), ..do_delete(rest, k)]
+        [Pair(k2, v2), ..do_delete(rest, k)]
       }
   }
 }
@@ -139,9 +139,9 @@ test delete_6() {
 ///     |> dict.insert(key: "b", value: 200)
 ///     |> dict.insert(key: "c", value: 300)
 ///     |> dict.filter(fn(k, _v) { k != "a" })
-///     |> dict.to_list()
+///     |> dict.to_map()
 ///
-/// result == [("b", 200), ("c", 300)]
+/// result == [Pair("b", 200), Pair("c", 300)]
 /// ```
 pub fn filter(
   self: Dict<key, value>,
@@ -151,15 +151,15 @@ pub fn filter(
 }
 
 fn do_filter(
-  self: List<(ByteArray, value)>,
+  self: Map<ByteArray, value>,
   with: fn(ByteArray, value) -> Bool,
-) -> List<(ByteArray, value)> {
+) -> Map<ByteArray, value> {
   when self is {
     [] ->
       []
-    [(k, v), ..rest] ->
+    [Pair(k, v), ..rest] ->
       if with(k, v) {
-        [(k, v), ..do_filter(rest, with)]
+        [Pair(k, v), ..do_filter(rest, with)]
       } else {
         do_filter(rest, with)
       }
@@ -200,10 +200,10 @@ pub fn find(self: Dict<key, value>, value v: value) -> Option<ByteArray> {
   do_find(self.inner, v)
 }
 
-fn do_find(self: List<(ByteArray, value)>, value v: value) -> Option<ByteArray> {
+fn do_find(self: Map<ByteArray, value>, value v: value) -> Option<ByteArray> {
   when self is {
     [] -> None
-    [(k2, v2), ..rest] ->
+    [Pair(k2, v2), ..rest] ->
       if v == v2 {
         Some(k2)
       } else {
@@ -264,13 +264,13 @@ pub fn foldr(
 }
 
 fn do_foldr(
-  self: List<(ByteArray, value)>,
+  self: Map<ByteArray, value>,
   zero: result,
   with: fn(ByteArray, value, result) -> result,
 ) -> result {
   when self is {
     [] -> zero
-    [(k, v), ..rest] -> with(k, v, do_foldr(rest, zero, with))
+    [Pair(k, v), ..rest] -> with(k, v, do_foldr(rest, zero, with))
   }
 }
 
@@ -304,13 +304,13 @@ pub fn foldl(
 }
 
 fn do_foldl(
-  self: List<(ByteArray, value)>,
+  self: Map<ByteArray, value>,
   zero: result,
   with: fn(ByteArray, value, result) -> result,
 ) -> result {
   when self is {
     [] -> zero
-    [(k, v), ..rest] -> do_foldl(rest, with(k, v, zero), with)
+    [Pair(k, v), ..rest] -> do_foldl(rest, with(k, v, zero), with)
   }
 }
 
@@ -326,159 +326,159 @@ test fold_2() {
 /// multiple times, the first occurrence prevails.
 ///
 /// ```aiken
-/// let list = [("a", 100), ("c", 300), ("b", 200)]
+/// let map = [Pair("a", 100), Pair("c", 300), Pair("b", 200)]
 ///
 /// let result =
-///   dict.from_list(list)
-///     |> dict.to_list()
+///   dict.from_map(map)
+///     |> dict.to_map()
 ///
-/// result == [("a", 100), ("b", 200), ("c", 300)]
+/// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
-pub fn from_list(self: List<(ByteArray, value)>) -> Dict<key, value> {
-  Dict { inner: do_from_list(self) }
+pub fn from_map(self: Map<ByteArray, value>) -> Dict<key, value> {
+  Dict { inner: do_from_map(self) }
 }
 
-fn do_from_list(xs: List<(ByteArray, value)>) -> List<(ByteArray, value)> {
+fn do_from_map(xs: Map<ByteArray, value>) -> Map<ByteArray, value> {
   when xs is {
     [] ->
       []
-    [(k, v), ..rest] -> do_insert(do_from_list(rest), k, v)
+    [Pair(k, v), ..rest] -> do_insert(do_from_map(rest), k, v)
   }
 }
 
-test from_list_1() {
-  from_list([]) == new()
+test from_map_1() {
+  from_map([]) == new()
 }
 
-test from_list_2() {
-  from_list([(foo, 42), (bar, 14)]) == from_list([(bar, 14), (foo, 42)])
+test from_map_2() {
+  from_map([Pair(foo, 42), Pair(bar, 14)]) == from_map(
+    [Pair(bar, 14), Pair(foo, 42)],
+  )
 }
 
-test from_list_3() {
-  from_list([(foo, 42), (bar, 14)]) == fixture_1()
+test from_map_3() {
+  from_map([Pair(foo, 42), Pair(bar, 14)]) == fixture_1()
 }
 
-test from_list_4() {
-  from_list([(foo, 42), (bar, 14), (foo, 1337)]) == fixture_1()
+test from_map_4() {
+  from_map([Pair(foo, 42), Pair(bar, 14), Pair(foo, 1337)]) == fixture_1()
 }
 
-test bench_from_list() {
+test bench_from_map() {
   let dict =
-    from_list(
+    from_map(
       [
-        ("bbba", 8),
-        ("bbab", 12),
-        ("aabb", 13),
-        ("aaab", 9),
-        ("bbbb", 16),
-        ("aaaa", 1),
-        ("aaba", 5),
-        ("abab", 10),
-        ("baba", 7),
-        ("baab", 11),
-        ("abaa", 2),
-        ("baaa", 3),
-        ("bbaa", 4),
-        ("babb", 15),
-        ("abbb", 14),
-        ("abba", 6),
+        Pair("bbba", 8),
+        Pair("bbab", 12),
+        Pair("aabb", 13),
+        Pair("aaab", 9),
+        Pair("bbbb", 16),
+        Pair("aaaa", 1),
+        Pair("aaba", 5),
+        Pair("abab", 10),
+        Pair("baba", 7),
+        Pair("baab", 11),
+        Pair("abaa", 2),
+        Pair("baaa", 3),
+        Pair("bbaa", 4),
+        Pair("babb", 15),
+        Pair("abbb", 14),
+        Pair("abba", 6),
       ],
     )
 
   size(dict) == 16
 }
 
-/// Like ['from_list'](from_list), but from an already sorted list by ascending
+/// Like ['from_map'](from_map), but from an already sorted list by ascending
 /// keys. This function fails (i.e. halt the program execution) if the list isn't
 /// sorted.
 ///
 /// ```aiken
-/// let list = [("a", 100), ("b", 200), ("c", 300)]
+/// let map = [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 ///
 /// let result =
-///   dict.from_ascending_list(list)
-///     |> dict.to_list()
+///   dict.from_ascending_map(map)
+///     |> dict.to_map()
 ///
-/// result == [("a", 100), ("b", 200), ("c", 300)]
+/// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
 ///
 /// This is meant to be used to turn a list constructed off-chain into a `Dict`
 /// which has taken care of maintaining interval invariants. This function still
 /// performs a sanity check on all keys to avoid silly mistakes. It is, however,
-/// considerably faster than ['from_list'](from_list)
-pub fn from_ascending_list(xs: List<(ByteArray, value)>) -> Dict<key, value> {
-  let Void = check_ascending_list(xs)
+/// considerably faster than ['from_map'](from_map)
+pub fn from_ascending_map(xs: Map<ByteArray, value>) -> Dict<key, value> {
+  let Void = check_ascending_map(xs)
   Dict { inner: xs }
 }
 
-fn check_ascending_list(xs: List<(ByteArray, value)>) {
+fn check_ascending_map(xs: Map<ByteArray, value>) {
   when xs is {
     [] -> Void
     [_] -> Void
-    [(x0, _), (x1, _) as e, ..rest] ->
+    [Pair(x0, _), Pair(x1, _) as e, ..rest] ->
       if builtin.less_than_bytearray(x0, x1) {
-        check_ascending_list([e, ..rest])
+        check_ascending_map([e, ..rest])
       } else {
         fail @"keys in associative list aren't in ascending order"
       }
   }
 }
 
-pub fn from_ascending_list_with(
-  xs: List<(key, value)>,
-  compare: fn(key, key) -> Ordering,
+pub fn from_ascending_map_with(
+  xs: Map<ByteArray, value>,
   value_predicate: fn(value) -> Bool,
 ) -> Dict<key, value> {
-  let Void = check_ascending_list_with(xs, compare, value_predicate)
+  let Void = check_ascending_map_with(xs, value_predicate)
   Dict { inner: xs }
 }
 
-fn check_ascending_list_with(
-  xs: List<(key, value)>,
-  compare: fn(key, key) -> Ordering,
+fn check_ascending_map_with(
+  xs: Map<ByteArray, value>,
   value_predicate: fn(value) -> Bool,
 ) {
   when xs is {
     [] -> Void
-    [(_, v)] ->
+    [Pair(_, v)] ->
       if value_predicate(v) {
         Void
       } else {
         fail @"value doesn't satisfy predicate"
       }
-    [(x0, v0), (x1, _) as e, ..rest] ->
-      when compare(x0, x1) is {
-        Less ->
-          if value_predicate(v0) {
-            check_ascending_list_with([e, ..rest], compare, value_predicate)
-          } else {
-            fail @"value doesn't satisfy predicate"
-          }
-        _ -> fail @"keys in associative list aren't in ascending order"
+    [Pair(x0, v0), Pair(x1, _) as e, ..rest] ->
+      if builtin.less_than_bytearray(x0, x1) {
+        if value_predicate(v0) {
+          check_ascending_map_with([e, ..rest], value_predicate)
+        } else {
+          fail @"value doesn't satisfy predicate"
+        }
+      } else {
+        fail @"keys in associative list aren't in ascending order"
       }
   }
 }
 
-test bench_from_ascending_list() {
+test bench_from_ascending_map() {
   let dict =
-    from_ascending_list(
+    from_ascending_map(
       [
-        ("aaaa", 1),
-        ("aaab", 9),
-        ("aaba", 5),
-        ("aabb", 13),
-        ("abaa", 2),
-        ("abab", 10),
-        ("abba", 6),
-        ("abbb", 14),
-        ("baaa", 3),
-        ("baab", 11),
-        ("baba", 7),
-        ("babb", 15),
-        ("bbaa", 4),
-        ("bbab", 12),
-        ("bbba", 8),
-        ("bbbb", 16),
+        Pair("aaaa", 1),
+        Pair("aaab", 9),
+        Pair("aaba", 5),
+        Pair("aabb", 13),
+        Pair("abaa", 2),
+        Pair("abab", 10),
+        Pair("abba", 6),
+        Pair("abbb", 14),
+        Pair("baaa", 3),
+        Pair("baab", 11),
+        Pair("baba", 7),
+        Pair("babb", 15),
+        Pair("bbaa", 4),
+        Pair("bbab", 12),
+        Pair("bbba", 8),
+        Pair("bbbb", 16),
       ],
     )
 
@@ -499,10 +499,10 @@ pub fn get(self: Dict<key, value>, key: ByteArray) -> Option<value> {
   do_get(self.inner, key)
 }
 
-fn do_get(self: List<(ByteArray, value)>, key k: ByteArray) -> Option<value> {
+fn do_get(self: Map<ByteArray, value>, key k: ByteArray) -> Option<value> {
   when self is {
     [] -> None
-    [(k2, v), ..rest] ->
+    [Pair(k2, v), ..rest] ->
       if builtin.less_than_equals_bytearray(k, k2) {
         if k == k2 {
           Some(v)
@@ -583,10 +583,10 @@ pub fn has_key(self: Dict<key, value>, key k: ByteArray) -> Bool {
   do_has_key(self.inner, k)
 }
 
-fn do_has_key(self: List<(ByteArray, value)>, key k: ByteArray) -> Bool {
+fn do_has_key(self: Map<ByteArray, value>, key k: ByteArray) -> Bool {
   when self is {
     [] -> False
-    [(k2, _), ..rest] ->
+    [Pair(k2, _), ..rest] ->
       if builtin.less_than_equals_bytearray(k, k2) {
         k == k2
       } else {
@@ -632,9 +632,9 @@ test has_key_4() {
 ///     |> dict.insert(key: "a", value: 1)
 ///     |> dict.insert(key: "b", value: 2)
 ///     |> dict.insert(key: "a", value: 3)
-///     |> dict.to_list()
+///     |> dict.to_map()
 ///
-/// result == [("a", 3), ("b", 2)]
+/// result == [Pair("a", 3), Pair("b", 2)]
 /// ```
 pub fn insert(
   self: Dict<key, value>,
@@ -645,21 +645,21 @@ pub fn insert(
 }
 
 fn do_insert(
-  self: List<(ByteArray, value)>,
+  self: Map<ByteArray, value>,
   key k: ByteArray,
   value v: value,
-) -> List<(ByteArray, value)> {
+) -> Map<ByteArray, value> {
   when self is {
     [] ->
-      [(k, v)]
-    [(k2, v2), ..rest] ->
+      [Pair(k, v)]
+    [Pair(k2, v2), ..rest] ->
       if builtin.less_than_bytearray(k, k2) {
-        [(k, v), ..self]
+        [Pair(k, v), ..self]
       } else {
         if k == k2 {
-          [(k, v), ..rest]
+          [Pair(k, v), ..rest]
         } else {
-          [(k2, v2), ..do_insert(rest, k, v)]
+          [Pair(k2, v2), ..do_insert(rest, k, v)]
         }
       }
   }
@@ -697,9 +697,9 @@ test insert_2() {
 ///     |> dict.insert_with(key: "a", value: 1, with: sum)
 ///     |> dict.insert_with(key: "b", value: 2, with: sum)
 ///     |> dict.insert_with(key: "a", value: 3, with: sum)
-///     |> dict.to_list()
+///     |> dict.to_map()
 ///
-/// result == [("a", 4), ("b", 2)]
+/// result == [Pair("a", 4), Pair("b", 2)]
 /// ```
 pub fn insert_with(
   self: Dict<key, value>,
@@ -720,9 +720,9 @@ test insert_with_1() {
     new()
       |> insert_with(key: "foo", value: 1, with: sum)
       |> insert_with(key: "bar", value: 2, with: sum)
-      |> to_list()
+      |> to_map()
 
-  result == [("bar", 2), ("foo", 1)]
+  result == [Pair("bar", 2), Pair("foo", 1)]
 }
 
 test insert_with_2() {
@@ -734,9 +734,9 @@ test insert_with_2() {
       |> insert_with(key: "foo", value: 1, with: sum)
       |> insert_with(key: "bar", value: 2, with: sum)
       |> insert_with(key: "foo", value: 3, with: sum)
-      |> to_list()
+      |> to_map()
 
-  result == [("bar", 2), ("foo", 4)]
+  result == [Pair("bar", 2), Pair("foo", 4)]
 }
 
 test insert_with_3() {
@@ -755,9 +755,9 @@ test insert_with_3() {
       |> insert_with(key: "bar", value: 2, with: with)
       |> insert_with(key: "foo", value: 3, with: with)
       |> insert_with(key: "bar", value: 4, with: with)
-      |> to_list()
+      |> to_map()
 
-  result == [("foo", 1)]
+  result == [Pair("foo", 1)]
 }
 
 /// Efficiently checks whether a dictionary is empty.
@@ -791,11 +791,11 @@ pub fn keys(self: Dict<key, value>) -> List<ByteArray> {
   do_keys(self.inner)
 }
 
-fn do_keys(self: List<(ByteArray, value)>) -> List<ByteArray> {
+fn do_keys(self: Map<ByteArray, value>) -> List<ByteArray> {
   when self is {
     [] ->
       []
-    [(k, _), ..rest] ->
+    [Pair(k, _), ..rest] ->
       [k, ..do_keys(rest)]
   }
 }
@@ -821,23 +821,23 @@ test keys_2() {
 ///     |> dict.insert("b", 200)
 ///     |> dict.insert("c", 300)
 ///     |> dict.map(fn(_k, v) { v * 2 })
-///     |> dict.to_list()
+///     |> dict.to_map()
 ///
-///  result == [("a", 200), ("b", 400), ("c", 600)]
+///  result == [Pair("a", 200), Pair("b", 400), Pair("c", 600)]
 /// ```
 pub fn map(self: Dict<key, a>, with: fn(ByteArray, a) -> b) -> Dict<key, b> {
   Dict { inner: do_map(self.inner, with) }
 }
 
 fn do_map(
-  self: List<(ByteArray, a)>,
+  self: Map<ByteArray, a>,
   with: fn(ByteArray, a) -> b,
-) -> List<(ByteArray, b)> {
+) -> Map<ByteArray, b> {
   when self is {
     [] ->
       []
-    [(k, v), ..rest] ->
-      [(k, with(k, v)), ..do_map(rest, with)]
+    [Pair(k, v), ..rest] ->
+      [Pair(k, with(k, v)), ..do_map(rest, with)]
   }
 }
 
@@ -863,20 +863,20 @@ test map_2() {
 ///     |> dict.insert("a", 100)
 ///     |> dict.insert("b", 200)
 ///     |> dict.insert("c", 300)
-///     |> dict.to_list()
+///     |> dict.to_map()
 ///
-/// result == [("a", 100), ("b", 200), ("c", 300)]
+/// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
-pub fn to_list(self: Dict<key, value>) -> List<(ByteArray, value)> {
+pub fn to_map(self: Dict<key, value>) -> Map<ByteArray, value> {
   self.inner
 }
 
-test to_list_1() {
-  to_list(new()) == []
+test to_map_1() {
+  to_map(new()) == []
 }
 
-test to_list_2() {
-  to_list(fixture_1()) == [(bar, 14), (foo, 42)]
+test to_map_2() {
+  to_map(fixture_1()) == [Pair(bar, 14), Pair(foo, 42)]
 }
 
 /// Return the number of key-value pairs in the dictionary.
@@ -895,7 +895,7 @@ pub fn size(self: Dict<key, value>) -> Int {
   do_size(self.inner)
 }
 
-fn do_size(self: List<(key, value)>) -> Int {
+fn do_size(self: Map<key, value>) -> Int {
   when self is {
     [] -> 0
     [_, ..rest] -> 1 + do_size(rest)
@@ -925,13 +925,13 @@ test size_3() {
 /// right dictionary, values from the left are preferred (i.e. left-biaised).
 ///
 /// ```aiken
-/// let left_dict = dict.from_list([("a", 100), ("b", 200)])
-/// let right_dict = dict.from_list([("a", 150), ("c", 300)])
+/// let left_dict = dict.from_list([Pair("a", 100), Pair("b", 200)])
+/// let right_dict = dict.from_list([Pair("a", 150), Pair("c", 300)])
 ///
 /// let result =
-///   dict.union(left_dict, right_dict) |> dict.to_list()
+///   dict.union(left_dict, right_dict) |> dict.to_map()
 ///
-/// result == [("a", 100), ("b", 200), ("c", 300)]
+/// result == [Pair("a", 100), Pair("b", 200), Pair("c", 300)]
 /// ```
 pub fn union(
   left: Dict<key, value>,
@@ -941,12 +941,12 @@ pub fn union(
 }
 
 fn do_union(
-  left: List<(ByteArray, value)>,
-  right: List<(ByteArray, value)>,
-) -> List<(ByteArray, value)> {
+  left: Map<ByteArray, value>,
+  right: Map<ByteArray, value>,
+) -> Map<ByteArray, value> {
   when left is {
     [] -> right
-    [(k, v), ..rest] -> do_union(rest, do_insert(right, k, v))
+    [Pair(k, v), ..rest] -> do_union(rest, do_insert(right, k, v))
   }
 }
 
@@ -966,7 +966,9 @@ test union_3() {
     new()
       |> insert(bar, 42)
       |> insert(baz, 1337)
-  union(left, right) == from_list([(foo, 14), (baz, 1337), (bar, 42)])
+  union(left, right) == from_map(
+    [Pair(foo, 14), Pair(baz, 1337), Pair(bar, 42)],
+  )
 }
 
 test union_4() {
@@ -977,7 +979,7 @@ test union_4() {
     new()
       |> insert(bar, 42)
       |> insert(foo, 1337)
-  union(left, right) == from_list([(foo, 14), (bar, 42)])
+  union(left, right) == from_map([Pair(foo, 14), Pair(bar, 42)])
 }
 
 /// Like [`union`](#union) but allows specifying the behavior to adopt when a key is present
@@ -987,8 +989,8 @@ test union_4() {
 /// When passing `None`, the value is removed and not present in the union.
 ///
 /// ```aiken
-/// let left_dict = dict.from_list([("a", 100), ("b", 200)])
-/// let right_dict = dict.from_list([("a", 150), ("c", 300)])
+/// let left_dict = dict.from_map([Pair("a", 100), Pair("b", 200)])
+/// let right_dict = dict.from_map([Pair("a", 150), Pair("c", 300)])
 ///
 /// let result =
 ///   dict.union_with(
@@ -996,9 +998,9 @@ test union_4() {
 ///     right_dict,
 ///     fn(_k, v1, v2) { Some(v1 + v2) },
 ///   )
-///     |> dict.to_list()
+///     |> dict.to_map()
 ///
-/// result == [("a", 250), ("b", 200), ("c", 300)]
+/// result == [Pair("a", 250), Pair("b", 200), Pair("c", 300)]
 /// ```
 pub fn union_with(
   left: Dict<key, value>,
@@ -1009,38 +1011,38 @@ pub fn union_with(
 }
 
 fn do_union_with(
-  left: List<(ByteArray, value)>,
-  right: List<(ByteArray, value)>,
+  left: Map<ByteArray, value>,
+  right: Map<ByteArray, value>,
   with: fn(ByteArray, value, value) -> Option<value>,
-) -> List<(ByteArray, value)> {
+) -> Map<ByteArray, value> {
   when left is {
     [] -> right
-    [(k, v), ..rest] ->
+    [Pair(k, v), ..rest] ->
       do_union_with(rest, do_insert_with(right, k, v, with), with)
   }
 }
 
 fn do_insert_with(
-  self: List<(ByteArray, value)>,
+  self: Map<ByteArray, value>,
   key k: ByteArray,
   value v: value,
   with: fn(ByteArray, value, value) -> Option<value>,
-) -> List<(ByteArray, value)> {
+) -> Map<ByteArray, value> {
   when self is {
     [] ->
-      [(k, v)]
-    [(k2, v2), ..rest] ->
+      [Pair(k, v)]
+    [Pair(k2, v2), ..rest] ->
       if builtin.less_than_bytearray(k, k2) {
-        [(k, v), ..self]
+        [Pair(k, v), ..self]
       } else {
         if k == k2 {
           when with(k, v, v2) is {
             Some(combined) ->
-              [(k, combined), ..rest]
+              [Pair(k, combined), ..rest]
             None -> rest
           }
         } else {
-          [(k2, v2), ..do_insert_with(rest, k, v, with)]
+          [Pair(k2, v2), ..do_insert_with(rest, k, v, with)]
         }
       }
   }
@@ -1058,7 +1060,7 @@ test union_with_1() {
 
   let result = union_with(left, right, with: fn(_, l, r) { Some(l + r) })
 
-  result == from_list([(foo, 1351), (bar, 42)])
+  result == from_map([Pair(foo, 1351), Pair(bar, 42)])
 }
 
 /// Extract all the values present in a given `Dict`.
@@ -1077,11 +1079,11 @@ pub fn values(self: Dict<key, value>) -> List<value> {
   do_values(self.inner)
 }
 
-fn do_values(self: List<(key, value)>) -> List<value> {
+fn do_values(self: Map<key, value>) -> List<value> {
   when self is {
     [] ->
       []
-    [(_, v), ..rest] ->
+    [Pair(_, v), ..rest] ->
       [v, ..do_values(rest)]
   }
 }

--- a/lib/aiken/dict.ak
+++ b/lib/aiken/dict.ak
@@ -23,7 +23,7 @@ pub opaque type Dict<key, value> {
   inner: Map<ByteArray, value>,
 }
 
-/// Create a new map
+/// Create a new empty Dict
 /// ```aiken
 /// dict.to_map(dict.new()) == []
 /// ```
@@ -194,7 +194,7 @@ test filter_3() {
 ///     |> dict.insert(key: "c", value: 42)
 ///     |> dict.find(42)
 ///
-/// result == Some("c")
+/// result == Some("a")
 /// ```
 pub fn find(self: Dict<key, value>, value v: value) -> Option<ByteArray> {
   do_find(self.inner, v)
@@ -686,7 +686,8 @@ test insert_2() {
 }
 
 /// Insert a value in the dictionary at a given key. When the key already exist, the provided
-/// merge function is called.
+/// merge function is called. The value existing in the dictionary is passed as the second argument
+/// to the merge function, and the new value is passed as the third argument.
 ///
 /// ```aiken
 /// let sum =

--- a/lib/aiken/map.ak
+++ b/lib/aiken/map.ak
@@ -1,0 +1,580 @@
+//// A module for working with Map Data.
+////
+//// These Maps are non-ordered lists of key-value pairs,
+//// which preserve no invariant on the order of the keys or the duplication of keys.
+
+/// Remove a single key-value pair from the Map. If the key is not found, no changes are made.
+/// Duplicate keys are not removed. Only the **first** key found is removed.
+///
+/// ```aiken
+/// map.remove_first([], "a") == []
+/// map.remove_first([Pair("a", 1)], "a") == []
+/// map.remove_first([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
+/// map.remove_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("b", 2), Pair("a", 3)]
+/// ```
+pub fn remove_first(self: Map<key, value>, key k: key) -> Map<key, value> {
+  when self is {
+    [] ->
+      []
+    [Pair(k2, v2), ..rest] ->
+      if k == k2 {
+        rest
+      } else {
+        [Pair(k2, v2), ..remove_first(rest, k)]
+      }
+  }
+}
+
+test remove_first_1() {
+  remove_first([], "a") == []
+}
+
+test remove_first_2() {
+  remove_first([Pair("a", 14)], "a") == []
+}
+
+test remove_first_3() {
+  let fixture =
+    [Pair("a", 14)]
+  remove_first(fixture, "b") == fixture
+}
+
+test remove_first_4() {
+  let fixture =
+    [Pair("a", 1), Pair("b", 2), Pair("a", 3)]
+  remove_first(fixture, "a") == [Pair("b", 2), Pair("a", 3)]
+}
+
+/// Remove a single key-value pair from the Map. If the key is not found, no changes are made.
+/// Duplicate keys are not removed. Only the **last** key found is removed.
+///
+/// ```aiken
+/// map.remove_last([], "a") == []
+/// map.remove_last([Pair("a", 1)], "a") == []
+/// map.remove_last([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
+/// map.remove_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("a", 1), Pair("b", 2)]
+/// ```
+pub fn remove_last(self: Map<key, value>, key k: key) -> Map<key, value> {
+  when self is {
+    [] ->
+      []
+    [Pair(k2, v2), ..rest] ->
+      if k == k2 {
+        let tail = remove_last(rest, k)
+        if tail == rest {
+          rest
+        } else {
+          [Pair(k2, v2), ..tail]
+        }
+      } else {
+        [Pair(k2, v2), ..remove_last(rest, k)]
+      }
+  }
+}
+
+test remove_last_1() {
+  remove_last([], "a") == []
+}
+
+test remove_last_2() {
+  remove_last([Pair("a", 14)], "a") == []
+}
+
+test remove_last_3() {
+  let fixture =
+    [Pair("a", 14)]
+  remove_last(fixture, "b") == fixture
+}
+
+test remove_last_4() {
+  let fixture =
+    [Pair("a", 1), Pair("b", 2), Pair("a", 3)]
+  remove_last(fixture, "a") == [Pair("a", 1), Pair("b", 2)]
+}
+
+/// Remove all key-value pairs matching the key from the Map. If the key is not found, no changes are made.
+///
+/// ```aiken
+/// map.remove_all([], "a") == []
+/// map.remove_all([Pair("a", 1)], "a") == []
+/// map.remove_all([Pair("a", 1), Pair("b", 2)], "a") == [Pair("b", 2)]
+/// map.remove_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [Pair("b", 2)]
+/// ```
+pub fn remove_all(self: Map<key, value>, key k: key) -> Map<key, value> {
+  when self is {
+    [] ->
+      []
+    [Pair(k2, v2), ..rest] ->
+      if k == k2 {
+        remove_all(rest, k)
+      } else {
+        [Pair(k2, v2), ..remove_all(rest, k)]
+      }
+  }
+}
+
+test remove_all_1() {
+  remove_all([], "a") == []
+}
+
+test remove_all_2() {
+  remove_all([Pair("a", 14)], "a") == []
+}
+
+test remove_all_3() {
+  let fixture =
+    [Pair("a", 14)]
+  remove_all(fixture, "b") == fixture
+}
+
+test remove_all_4() {
+  let fixture =
+    [Pair("a", 1), Pair("b", 2), Pair("a", 3)]
+  remove_all(fixture, "a") == [Pair("b", 2)]
+}
+
+/// Finds the first key in the map associated with a given value, if any.
+///
+/// ```aiken
+/// map.find_first([], 1) == None
+/// map.find_first([Pair("a", 1)], 1) == Some("a")
+/// map.find_first([Pair("a", 1), Pair("b", 2)], 1) == Some("a")
+/// map.find_first([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == Some("a")
+/// ```
+pub fn find_first(self: Map<key, value>, v: value) -> Option<key> {
+  when self is {
+    [] -> None
+    [Pair(k2, v2), ..rest] ->
+      if v == v2 {
+        Some(k2)
+      } else {
+        find_first(rest, v)
+      }
+  }
+}
+
+test find_first_1() {
+  find_first([], "a") == None
+}
+
+test find_first_2() {
+  find_first([Pair("a", 14)], 14) == Some("a")
+}
+
+test find_first_3() {
+  find_first([Pair("a", 14)], 42) == None
+}
+
+test find_first_4() {
+  find_first([Pair("a", 14), Pair("b", 42), Pair("c", 14)], 14) == Some("a")
+}
+
+/// Finds the last key in the map associated with a given value, if any.
+///
+/// ```aiken
+/// map.find_last([], 1) == None
+/// map.find_last([Pair("a", 1)], 1) == Some("a")
+/// map.find_last([Pair("a", 1), Pair("b", 2)], 1) == Some("a")
+/// map.find_last([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == Some("c")
+/// ```
+pub fn find_last(self: Map<key, value>, v: value) -> Option<key> {
+  when self is {
+    [] -> None
+    [Pair(k2, v2), ..rest] ->
+      if v == v2 {
+        when find_last(rest, v) is {
+          None -> Some(k2)
+          some -> some
+        }
+      } else {
+        find_last(rest, v)
+      }
+  }
+}
+
+test find_last_1() {
+  find_last([], "a") == None
+}
+
+test find_last_2() {
+  find_last([Pair("a", 14)], 14) == Some("a")
+}
+
+test find_last_3() {
+  find_last([Pair("a", 14)], 42) == None
+}
+
+test find_last_4() {
+  find_last([Pair("a", 14), Pair("b", 42), Pair("c", 14)], 14) == Some("c")
+}
+
+/// Finds all keys in the map associated with a given value.
+///
+/// ```aiken
+/// map.find_all([], 1) == []
+/// map.find_all([Pair("a", 1)], 1) == ["a"]
+/// map.find_all([Pair("a", 1), Pair("b", 2)], 1) == ["a"]
+/// map.find_all([Pair("a", 1), Pair("b", 2), Pair("c", 1)], 1) == ["a", "c"]
+/// ```
+pub fn find_all(self: Map<key, value>, v: value) -> List<key> {
+  when self is {
+    [] ->
+      []
+    [Pair(k2, v2), ..rest] ->
+      if v == v2 {
+        [k2, ..find_all(rest, v)]
+      } else {
+        find_all(rest, v)
+      }
+  }
+}
+
+test find_all_1() {
+  find_all([], "a") == []
+}
+
+test find_all_2() {
+  find_all([Pair("a", 14)], 14) == ["a"]
+}
+
+test find_all_3() {
+  find_all([Pair("a", 14)], 42) == []
+}
+
+test find_all_4() {
+  find_all([Pair("a", 14), Pair("b", 42), Pair("c", 14)], 14) == ["a", "c"]
+}
+
+/// Fold over the key-value pairs in a Map. The fold direction follows the
+/// order of elements in the Map and is done from right-to-left.
+///
+/// ```aiken
+/// let fixture = [
+///   Pair(1, 100),
+///   Pair(2, 200),
+///   Pair(3, 300),
+/// ]
+///
+/// map.foldr(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
+/// ```
+pub fn foldr(
+  self: Map<key, value>,
+  zero: result,
+  with: fn(key, value, result) -> result,
+) -> result {
+  when self is {
+    [] -> zero
+    [Pair(k, v), ..rest] -> with(k, v, foldr(rest, zero, with))
+  }
+}
+
+test foldr_1() {
+  foldr([], 14, fn(_, _, _) { 42 }) == 14
+}
+
+test foldr_2() {
+  foldr(
+    [Pair("a", 42), Pair("b", 14)],
+    zero: 0,
+    with: fn(_, v, total) { v + total },
+  ) == 56
+}
+
+test foldr_3() {
+  let fixture =
+    [Pair(1, 100), Pair(2, 200), Pair(3, 300)]
+
+  foldr(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
+}
+
+/// Fold over the key-value pairs in a map. The fold direction follows keys
+/// in ascending order and is done from left-to-right.
+///
+/// ```aiken
+/// let fixture = [
+///   Pair(1, 100),
+///   Pair(2, 200),
+///   Pair(3, 300),
+/// ]
+///
+/// map.foldl(fixture, 0, fn(k, v, result) { k * v + result }) == 1400
+/// ```
+pub fn foldl(
+  self: Map<key, value>,
+  zero: result,
+  with: fn(key, value, result) -> result,
+) -> result {
+  when self is {
+    [] -> zero
+    [Pair(k, v), ..rest] -> foldl(rest, with(k, v, zero), with)
+  }
+}
+
+test foldl_1() {
+  foldl([], 14, fn(_, _, _) { 42 }) == 14
+}
+
+test foldl_2() {
+  foldl(
+    [Pair("a", 42), Pair("b", 14)],
+    zero: 0,
+    with: fn(_, v, total) { v + total },
+  ) == 56
+}
+
+/// Get the value in the map by its key.
+/// If multiple values with the same key exist, only the first one is returned.
+///
+/// ```aiken
+/// map.get_first([], "a") == None
+/// map.get_first([Pair("a", 1)], "a") == Some(1)
+/// map.get_first([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
+/// map.get_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(1)
+/// ```
+pub fn get_first(self: Map<key, value>, key k: key) -> Option<value> {
+  when self is {
+    [] -> None
+    [Pair(k2, v), ..rest] ->
+      if k == k2 {
+        Some(v)
+      } else {
+        get_first(rest, k)
+      }
+  }
+}
+
+test get_first_1() {
+  get_first([], "a") == None
+}
+
+test get_first_2() {
+  get_first([Pair("a", 1)], "a") == Some(1)
+}
+
+test get_first_3() {
+  get_first([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
+}
+
+test get_first_4() {
+  get_first([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(1)
+}
+
+test get_first_5() {
+  get_first([Pair("a", 1), Pair("b", 2), Pair("c", 3)], "d") == None
+}
+
+/// Get the value in the map by its key.
+/// If multiple values with the same key exist, only the last one is returned.
+///
+/// ```aiken
+/// map.get_last([], "a") == None
+/// map.get_last([Pair("a", 1)], "a") == Some(1)
+/// map.get_last([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
+/// map.get_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(3)
+/// ```
+pub fn get_last(self: Map<key, value>, key k: key) -> Option<value> {
+  when self is {
+    [] -> None
+    [Pair(k2, v), ..rest] ->
+      if k == k2 {
+        when get_last(rest, k) is {
+          None -> Some(v)
+          some -> some
+        }
+      } else {
+        get_last(rest, k)
+      }
+  }
+}
+
+test get_last_1() {
+  get_last([], "a") == None
+}
+
+test get_last_2() {
+  get_last([Pair("a", 1)], "a") == Some(1)
+}
+
+test get_last_3() {
+  get_last([Pair("a", 1), Pair("b", 2)], "a") == Some(1)
+}
+
+test get_last_4() {
+  get_last([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == Some(3)
+}
+
+test get_last_5() {
+  get_last([Pair("a", 1), Pair("b", 2), Pair("c", 3)], "d") == None
+}
+
+/// Get all values in the map associated with a given key.
+///
+/// ```aiken
+/// map.get_all([], "a") == []
+/// map.get_all([Pair("a", 1)], "a") == [1]
+/// map.get_all([Pair("a", 1), Pair("b", 2)], "a") == [1]
+/// map.get_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [1, 3]
+/// ```
+pub fn get_all(self: Map<key, value>, key k: key) -> List<value> {
+  when self is {
+    [] ->
+      []
+    [Pair(k2, v), ..rest] ->
+      if k == k2 {
+        [v, ..get_all(rest, k)]
+      } else {
+        get_all(rest, k)
+      }
+  }
+}
+
+test get_all_1() {
+  get_all([], "a") == []
+}
+
+test get_all_2() {
+  get_all([Pair("a", 1)], "a") == [1]
+}
+
+test get_all_3() {
+  get_all([Pair("a", 1), Pair("b", 2)], "a") == [1]
+}
+
+test get_all_4() {
+  get_all([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == [1, 3]
+}
+
+test get_all_5() {
+  get_all([Pair("a", 1), Pair("b", 2), Pair("c", 3)], "d") == []
+}
+
+/// Check if a key exists in the map.
+///
+/// ```aiken
+/// map.has_key([], "a") == False
+/// map.has_key([Pair("a", 1)], "a") == True
+/// map.has_key([Pair("a", 1), Pair("b", 2)], "a") == True
+/// map.has_key([Pair("a", 1), Pair("b", 2), Pair("a", 3)], "a") == True
+/// ```
+pub fn has_key(self: Map<key, value>, k: key) -> Bool {
+  when self is {
+    [] -> False
+    // || is lazy so this is fine
+    [Pair(k2, _), ..rest] -> k == k2 || has_key(rest, k)
+  }
+}
+
+test has_key_1() {
+  !has_key([], "a")
+}
+
+test has_key_2() {
+  has_key([Pair("a", 14)], "a")
+}
+
+test has_key_3() {
+  !has_key([Pair("a", 14)], "b")
+}
+
+test has_key_4() {
+  has_key([Pair("a", 14), Pair("b", 42)], "b")
+}
+
+test has_key_5() {
+  has_key([Pair("a", 14), Pair("b", 42), Pair("a", 42)], "a")
+}
+
+/// Extract all the keys present in a given `Map`.
+///
+/// ```aiken
+/// map.keys([]) == []
+/// map.keys([Pair("a", 1)]) == ["a"]
+/// map.keys([Pair("a", 1), Pair("b", 2)]) == ["a", "b"]
+/// map.keys([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == ["a", "b", "a"]
+/// ```
+pub fn keys(self: Map<key, value>) -> List<key> {
+  when self is {
+    [] ->
+      []
+    [Pair(k, _), ..rest] ->
+      [k, ..keys(rest)]
+  }
+}
+
+test keys_1() {
+  keys([]) == []
+}
+
+test keys_2() {
+  keys([Pair("a", 0)]) == ["a"]
+}
+
+test keys_3() {
+  keys([Pair("a", 0), Pair("b", 0)]) == ["a", "b"]
+}
+
+/// Apply a function to all key-value pairs in a map, replacing the values.
+///
+/// ```aiken
+/// let fixture = [Pair("a", 100), Pair("b", 200)]
+///
+/// map.map(fixture, fn(_k, v) { v * 2 }) == [Pair("a", 200), Pair("b", 400)]
+/// ```
+pub fn map(
+  self: Map<key, value>,
+  with: fn(key, value) -> result,
+) -> Map<key, result> {
+  when self is {
+    [] ->
+      []
+    [Pair(k, v), ..rest] ->
+      [Pair(k, with(k, v)), ..map(rest, with)]
+  }
+}
+
+test map_1() {
+  let fixture =
+    [Pair("a", 1), Pair("b", 2)]
+
+  map(fixture, with: fn(k, _) { k }) == [Pair("a", "a"), Pair("b", "b")]
+}
+
+test map_2() {
+  let fixture =
+    [Pair("a", 1), Pair("b", 2)]
+
+  map(fixture, with: fn(_, v) { v + 1 }) == [Pair("a", 2), Pair("b", 3)]
+}
+
+/// Extract all the values present in a given `Map`.
+///
+/// ```aiken
+/// map.values([]) == []
+/// map.values([Pair("a", 1)]) == [1]
+/// map.values([Pair("a", 1), Pair("b", 2)]) == [1, 2]
+/// map.values([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == [1, 2, 3]
+/// ```
+pub fn values(self: Map<key, value>) -> List<value> {
+  when self is {
+    [] ->
+      []
+    [Pair(_, v), ..rest] ->
+      [v, ..values(rest)]
+  }
+}
+
+test values_1() {
+  values([]) == []
+}
+
+test values_2() {
+  values([Pair("a", 1)]) == [1]
+}
+
+test values_3() {
+  values([Pair("a", 1), Pair("b", 2)]) == [1, 2]
+}
+
+test values_4() {
+  values([Pair("a", 1), Pair("b", 2), Pair("a", 3)]) == [1, 2, 3]
+}

--- a/lib/aiken/math/rational.ak
+++ b/lib/aiken/math/rational.ak
@@ -334,7 +334,7 @@ test ceil_1() {
   }
 }
 
-/// Returns the proper fraction of a given `Rational` `r`. That is, a pair of
+/// Returns the proper fraction of a given `Rational` `r`. That is, a 2-tuple of
 /// an `Int` and `Rational` (n, f) such that:
 ///
 /// - `r = n + f`;

--- a/lib/aiken/transaction.ak
+++ b/lib/aiken/transaction.ak
@@ -59,10 +59,10 @@ pub type Transaction {
   fee: Value,
   mint: MintedValue,
   certificates: List<Certificate>,
-  withdrawals: Dict<StakeCredential, Int>,
+  withdrawals: Map<StakeCredential, Int>,
   validity_range: ValidityRange,
   extra_signatories: List<Hash<Blake2b_224, VerificationKey>>,
-  redeemers: Dict<ScriptPurpose, Redeemer>,
+  redeemers: Map<ScriptPurpose, Redeemer>,
   datums: Dict<Hash<Blake2b_256, Data>, Data>,
   id: TransactionId,
 }
@@ -89,10 +89,10 @@ pub fn placeholder() -> Transaction {
     fee: value.zero(),
     mint: value.zero() |> value.to_minted_value(),
     certificates: [],
-    withdrawals: dict.new(),
+    withdrawals: [],
     validity_range: interval.everything(),
     extra_signatories: [],
-    redeemers: dict.new(),
+    redeemers: [],
     datums: dict.new(),
     id: TransactionId {
       hash: #"0000000000000000000000000000000000000000000000000000000000000000",
@@ -191,7 +191,7 @@ pub fn find_datum(
                     InlineDatum(data) ->
                       if
                       blake2b_256(builtin.serialise_data(data)) == datum_hash{
-                      
+
                         Some(data)
                       } else {
                         None

--- a/lib/aiken/transaction.ak
+++ b/lib/aiken/transaction.ak
@@ -59,10 +59,10 @@ pub type Transaction {
   fee: Value,
   mint: MintedValue,
   certificates: List<Certificate>,
-  withdrawals: Map<StakeCredential, Int>,
+  withdrawals: AList<StakeCredential, Int>,
   validity_range: ValidityRange,
   extra_signatories: List<Hash<Blake2b_224, VerificationKey>>,
-  redeemers: Map<ScriptPurpose, Redeemer>,
+  redeemers: AList<ScriptPurpose, Redeemer>,
   datums: Dict<Hash<Blake2b_256, Data>, Data>,
   id: TransactionId,
 }

--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -1,4 +1,4 @@
-use aiken/dict.{Dict, from_ascending_list_with}
+use aiken/dict.{Dict, from_ascending_map_with}
 use aiken/hash.{Blake2b_224, Hash}
 use aiken/list
 use aiken/option
@@ -230,7 +230,7 @@ pub fn add(
       dict.insert_with(
         self.inner,
         policy_id,
-        dict.from_ascending_list([(asset_name, quantity)]),
+        dict.from_ascending_map([Pair(asset_name, quantity)]),
         helper,
       ),
     )
@@ -436,14 +436,14 @@ test reduce_3() {
 ///
 /// This function is meant to turn arbitrary user-defined `Data` into safe `Value`,
 /// while checking for internal invariants.
-pub fn from_asset_list(xs: List<(PolicyId, List<(AssetName, Int)>)>) -> Value {
+pub fn from_asset_list(xs: Map<PolicyId, Map<AssetName, Int>>) -> Value {
   xs
     |> list.foldr(
         dict.new(),
         fn(inner, acc) {
-          expect (p, [_, ..] as x) = inner
+          expect Pair(p, [_, ..] as x) = inner
           x
-            |> from_ascending_list_with(bytearray.compare, fn(v) { v != 0 })
+            |> from_ascending_map_with(fn(v) { v != 0 })
             |> dict.insert_with(
                 acc,
                 p,
@@ -451,7 +451,6 @@ pub fn from_asset_list(xs: List<(PolicyId, List<(AssetName, Int)>)>) -> Value {
                 fn(_, _, _) {
                   fail @"Duplicate policy in the asset list."
                 },
-                bytearray.compare,
               )
         },
       )
@@ -464,29 +463,32 @@ test from_asset_list_1() {
 }
 
 test from_asset_list_2() fail {
-  let v = from_asset_list([(#"33", [])])
+  let v = from_asset_list([Pair(#"33", [])])
   v == zero()
 }
 
 test from_asset_list_3() fail {
-  let v = from_asset_list([(#"33", [(#"", 0)])])
+  let v = from_asset_list([Pair(#"33", [Pair(#"", 0)])])
   v != zero()
 }
 
 test from_asset_list_4() {
-  let v = from_asset_list([(#"33", [(#"", 1)])])
+  let v = from_asset_list([Pair(#"33", [Pair(#"", 1)])])
   flatten(v) == [(#"33", #"", 1)]
 }
 
 test from_asset_list_5() {
-  let v = from_asset_list([(#"33", [(#"", 1), (#"33", 1)])])
+  let v = from_asset_list([Pair(#"33", [Pair(#"", 1), Pair(#"33", 1)])])
   flatten(v) == [(#"33", #"", 1), (#"33", #"33", 1)]
 }
 
 test from_asset_list_6() fail {
   let v =
     from_asset_list(
-      [(#"33", [(#"", 1), (#"33", 1)]), (#"33", [(#"", 1), (#"33", 1)])],
+      [
+        Pair(#"33", [Pair(#"", 1), Pair(#"33", 1)]),
+        Pair(#"33", [Pair(#"", 1), Pair(#"33", 1)]),
+      ],
     )
   v != zero()
 }
@@ -494,7 +496,10 @@ test from_asset_list_6() fail {
 test from_asset_list_7() fail {
   let v =
     from_asset_list(
-      [(#"33", [(#"", 1), (#"33", 1)]), (#"34", [(#"", 1), (#"", 1)])],
+      [
+        Pair(#"33", [Pair(#"", 1), Pair(#"33", 1)]),
+        Pair(#"34", [Pair(#"", 1), Pair(#"", 1)]),
+      ],
     )
   v != zero()
 }
@@ -503,9 +508,9 @@ test from_asset_list_8() {
   let v =
     from_asset_list(
       [
-        (#"33", [(#"", 1), (#"33", 1)]),
-        (#"34", [(#"31", 1)]),
-        (#"35", [(#"", 1)]),
+        Pair(#"33", [Pair(#"", 1), Pair(#"33", 1)]),
+        Pair(#"34", [Pair(#"31", 1)]),
+        Pair(#"35", [Pair(#"", 1)]),
       ],
     )
   flatten(v) == [
@@ -520,9 +525,9 @@ test from_asset_list_9() {
   let v =
     from_asset_list(
       [
-        (#"35", [(#"", 1)]),
-        (#"33", [(#"", 1), (#"33", 1)]),
-        (#"34", [(#"31", 1)]),
+        Pair(#"35", [Pair(#"", 1)]),
+        Pair(#"33", [Pair(#"", 1), Pair(#"33", 1)]),
+        Pair(#"34", [Pair(#"31", 1)]),
       ],
     )
   flatten(v) == [
@@ -623,7 +628,7 @@ pub fn to_minted_value(self: Value) -> MintedValue {
 
 test to_minted_value_1() {
   let minted_value = to_minted_value(zero())
-  ( minted_value.inner |> dict.to_list |> list.length ) == 1
+  ( minted_value.inner |> dict.to_map |> list.length ) == 1
 }
 
 test to_minted_value_2() {
@@ -660,7 +665,7 @@ fn unchecked_add(
     dict.insert_with(
       self.inner,
       policy_id,
-      dict.from_ascending_list([(asset_name, quantity)]),
+      dict.from_ascending_map([Pair(asset_name, quantity)]),
       fn(_, left, _right) {
         Some(
           dict.insert_with(

--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -1,4 +1,4 @@
-use aiken/dict.{Dict, from_ascending_map_with}
+use aiken/dict.{Dict, from_ascending_alist_with}
 use aiken/hash.{Blake2b_224, Hash}
 use aiken/list
 use aiken/option
@@ -230,7 +230,7 @@ pub fn add(
       dict.insert_with(
         self.inner,
         policy_id,
-        dict.from_ascending_map([Pair(asset_name, quantity)]),
+        dict.from_ascending_alist([Pair(asset_name, quantity)]),
         helper,
       ),
     )
@@ -443,7 +443,7 @@ pub fn from_asset_list(xs: AList<PolicyId, AList<AssetName, Int>>) -> Value {
         fn(inner, acc) {
           expect Pair(p, [_, ..] as x) = inner
           x
-            |> from_ascending_map_with(fn(v) { v != 0 })
+            |> from_ascending_alist_with(fn(v) { v != 0 })
             |> dict.insert_with(
                 acc,
                 p,
@@ -628,7 +628,7 @@ pub fn to_minted_value(self: Value) -> MintedValue {
 
 test to_minted_value_1() {
   let minted_value = to_minted_value(zero())
-  ( minted_value.inner |> dict.to_map |> list.length ) == 1
+  ( minted_value.inner |> dict.to_alist |> list.length ) == 1
 }
 
 test to_minted_value_2() {
@@ -665,7 +665,7 @@ fn unchecked_add(
     dict.insert_with(
       self.inner,
       policy_id,
-      dict.from_ascending_map([Pair(asset_name, quantity)]),
+      dict.from_ascending_alist([Pair(asset_name, quantity)]),
       fn(_, left, _right) {
         Some(
           dict.insert_with(

--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -436,7 +436,7 @@ test reduce_3() {
 ///
 /// This function is meant to turn arbitrary user-defined `Data` into safe `Value`,
 /// while checking for internal invariants.
-pub fn from_asset_list(xs: Map<PolicyId, Map<AssetName, Int>>) -> Value {
+pub fn from_asset_list(xs: AList<PolicyId, AList<AssetName, Int>>) -> Value {
   xs
     |> list.foldr(
         dict.new(),

--- a/lib/aiken/transaction/value.ak
+++ b/lib/aiken/transaction/value.ak
@@ -1,4 +1,3 @@
-use aiken/bytearray
 use aiken/dict.{Dict, from_ascending_list_with}
 use aiken/hash.{Blake2b_224, Hash}
 use aiken/list
@@ -57,9 +56,9 @@ pub fn from_asset(
   } else {
     let asset =
       dict.new()
-        |> dict.insert(asset_name, quantity, bytearray.compare)
+        |> dict.insert(asset_name, quantity)
     dict.new()
-      |> dict.insert(policy_id, asset, bytearray.compare)
+      |> dict.insert(policy_id, asset)
       |> Value
   }
 }
@@ -129,7 +128,6 @@ pub fn merge(left v0: Value, right v1: Value) -> Value {
                 Some(q)
               }
             },
-            bytearray.compare,
           )
         if dict.is_empty(result) {
           None
@@ -137,7 +135,6 @@ pub fn merge(left v0: Value, right v1: Value) -> Value {
           Some(result)
         }
       },
-      bytearray.compare,
     ),
   )
 }
@@ -221,7 +218,6 @@ pub fn add(
                 Some(q)
               }
             },
-            bytearray.compare,
           )
         if dict.is_empty(inner_result) {
           None
@@ -234,9 +230,8 @@ pub fn add(
       dict.insert_with(
         self.inner,
         policy_id,
-        dict.from_ascending_list([(asset_name, quantity)], bytearray.compare),
+        dict.from_ascending_list([(asset_name, quantity)]),
         helper,
-        bytearray.compare,
       ),
     )
   }
@@ -622,11 +617,7 @@ test from_minted_value_5() {
 /// Convert a [`Value`](#Value) into a [`MintedValue`](#MintedValue).
 pub fn to_minted_value(self: Value) -> MintedValue {
   self.inner
-    |> dict.insert(
-        ada_policy_id,
-        dict.insert(dict.new(), ada_asset_name, 0, bytearray.compare),
-        bytearray.compare,
-      )
+    |> dict.insert(ada_policy_id, dict.insert(dict.new(), ada_asset_name, 0))
     |> MintedValue
 }
 
@@ -669,7 +660,7 @@ fn unchecked_add(
     dict.insert_with(
       self.inner,
       policy_id,
-      dict.from_ascending_list([(asset_name, quantity)], bytearray.compare),
+      dict.from_ascending_list([(asset_name, quantity)]),
       fn(_, left, _right) {
         Some(
           dict.insert_with(
@@ -677,11 +668,9 @@ fn unchecked_add(
             asset_name,
             quantity,
             fn(_k, ql, qr) { Some(ql + qr) },
-            bytearray.compare,
           ),
         )
       },
-      bytearray.compare,
     ),
   )
 }


### PR DESCRIPTION
  Looking at Aiken's repositories in the wild, no one is using Dict with
  anything else than ByteArray as key. The extra complexity we bring
  just for making it generic in the key argument seems not worth it.

  Plus, if we know the key is a ByteArray, we can perform some
  optimizations on a few functions looking for keys to short-circuit
  them instead of traversing a list entirely.

  Here's a comparison of the mem and cpu cost before and after the
  chance for a few tests (omitted tests have identical cost).

  | mem     | cpu     | bench                     |
  | ---     | ---     | ---                       |
  | -10.15% | -5.88%  | delete_3                  |
  | -4.00%  | -9.68%  | delete_4                  |
  | -3.80%  | -9.39%  | delete_5                  |
  | -31.03% | -42.88% | delete_6                  |
  | -15.26% | -26.34% | find_4                    |
  | -11.10% | -18.85% | from_list_2               |
  | -8.02%  | -16.26% | from_list_3               |
  | -12.15% | -25.39% | from_list_4               |
  | -19.24% | -36.11% | bench_from_list           |
  | -17.79% | -18.91% | bench_from_ascending_list |
  | -4.91%  | -10.58% | get_2                     |
  | -9.49%  | -14.63% | get_3                     |
  | -29.94% | -42.75% | get_4                     |
  | -23.66% | -37.70% | get_5                     |
  | -7.94%  | -5.03%  | has_key_3                 |
  | -9.97%  | -18.50% | has_key_4                 |
  | -16.46% | -23.61% | insert_1                  |
  | -16.52% | -26.24% | insert_2                  |
  | -13.82% | -22.08% | insert_with_1             |
  | -18.77% | -29.88% | insert_with_2             |
  | -19.12% | -30.52% | insert_with_3             |
  | -10.47% | -17.40% | keys_2                    |
  | 4.25%   | 5.06%   | map_1                     |
  | 2.94%   | 3.31%   | map_2                     |
  | -10.99% | -19.83% | size_3                    |
  | -7.94%  | -16.17% | union_1                   |
  | -17.74% | -28.17% | union_3                   |
  | -16.96% | -26.55% | union_4                   |
  | -15.91% | -25.10% | union_with_1              |
  | -10.47% | -17.39% | values_2                  |