### PR TITLE
Removed references to PosixTime

### DIFF
--- a/lib/aiken/interval.ak
+++ b/lib/aiken/interval.ak
@@ -22,7 +22,7 @@
 ///
 /// ```aiken
 /// // [1; 10]
-/// let i0: Interval<PosixTime> = Interval
+/// let i0: Interval<Int> = Interval
 ///   { lower_bound:
 ///       IntervalBound { bound_type: Finite(1), is_inclusive: True }
 ///   , upper_bound:
@@ -32,7 +32,7 @@
 ///
 /// ```aiken
 /// // (20; infinity)
-/// let i1: Interval<PosixTime> = Interval
+/// let i1: Interval<Int> = Interval
 ///   { lower_bound:
 ///       IntervalBound { bound_type: Finite(20), is_inclusive: False }
 ///   , upper_bound:


### PR DESCRIPTION
as per title, `PosixTime`'s alias has been removed, hence removing references in docs.