### PR TITLE
Updated credentials name w/ new ones after lib update

### DIFF
--- a/lib/cardano/address.ak
+++ b/lib/cardano/address.ak
@@ -79,8 +79,8 @@ pub type StakeCredential =
 /// A 'PaymentCredential' represents the spending conditions associated with
 /// some output. Hence,
 ///
-/// - a `VerificationKeyCredential` captures an output locked by a public/private key pair;
-/// - and a `ScriptCredential` captures an output locked by a native or Plutus script.
+/// - a `VerificationKey` captures an output locked by a public/private key pair;
+/// - and a `Script` captures an output locked by a native or Plutus script.
 ///
 pub type PaymentCredential =
   Credential


### PR DESCRIPTION
As per release note:

> The constructors of [Credential](https://aiken-lang.github.io/stdlib/cardano/address.html#credential) have been renamed from VerificationKeyCredential and ScriptCredential into VerificationKey and Script respectively.

Updated docs accordingly