### PR TITLE
Scott encoding alternative for dict functions

### DIFF
--- a/lib/aiken/collection/dict.ak
+++ b/lib/aiken/collection/dict.ak
@@ -751,6 +751,24 @@ pub fn insert_with(
   }
 }
 
+pub fn insert_with_alt(
+  self: Dict<key, value>,
+  key k: ByteArray,
+  value v: value,
+  with: fn(ByteArray, value, value) ->
+    fn(fn(value) -> Pairs<ByteArray, value>, fn() -> Pairs<ByteArray, value>) ->
+      Pairs<ByteArray, value>,
+) -> Dict<key, value> {
+  Dict {
+    inner: do_insert_with_alt(
+      self.inner,
+      k,
+      v,
+      fn(k, v1, v2) { with(k, v2, v1) },
+    ),
+  }
+}
+
 test insert_with_1() {
   let sum =
     fn(_k, a, b) { Some(a + b) }
@@ -759,6 +777,19 @@ test insert_with_1() {
     empty
       |> insert_with(key: "foo", value: 1, with: sum)
       |> insert_with(key: "bar", value: 2, with: sum)
+      |> to_pairs()
+
+  result == [Pair("bar", 2), Pair("foo", 1)]
+}
+
+test insert_with_alt_1() {
+  let sum =
+    fn(_k, a, b) { fn(som, _non) { som(a + b) } }
+
+  let result =
+    empty
+      |> insert_with_alt(key: "foo", value: 1, with: sum)
+      |> insert_with_alt(key: "bar", value: 2, with: sum)
       |> to_pairs()
 
   result == [Pair("bar", 2), Pair("foo", 1)]
@@ -1016,6 +1047,16 @@ pub fn union_with(
   Dict { inner: do_union_with(left.inner, right.inner, with) }
 }
 
+pub fn union_with_alt(
+  left: Dict<key, value>,
+  right: Dict<key, value>,
+  with: fn(ByteArray, value, value) ->
+    fn(fn(value) -> Pairs<ByteArray, value>, fn() -> Pairs<ByteArray, value>) ->
+      Pairs<ByteArray, value>,
+) -> Dict<key, value> {
+  Dict { inner: do_union_with_alt(left.inner, right.inner, with) }
+}
+
 fn do_union_with(
   left: Pairs<ByteArray, value>,
   right: Pairs<ByteArray, value>,
@@ -1025,6 +1066,20 @@ fn do_union_with(
     [] -> right
     [Pair(k, v), ..rest] ->
       do_union_with(rest, do_insert_with(right, k, v, with), with)
+  }
+}
+
+fn do_union_with_alt(
+  left: Pairs<ByteArray, value>,
+  right: Pairs<ByteArray, value>,
+  with: fn(ByteArray, value, value) ->
+    fn(fn(value) -> Pairs<ByteArray, value>, fn() -> Pairs<ByteArray, value>) ->
+      Pairs<ByteArray, value>,
+) -> Pairs<ByteArray, value> {
+  when left is {
+    [] -> right
+    [Pair(k, v), ..rest] ->
+      do_union_with_alt(rest, do_insert_with_alt(right, k, v, with), with)
   }
 }
 
@@ -1047,6 +1102,32 @@ fn do_insert_with(
           }
         } else {
           [Pair(k2, v2), ..do_insert_with(rest, k, v, with)]
+        }
+      }
+  }
+}
+
+fn do_insert_with_alt(
+  self: Pairs<ByteArray, value>,
+  key k: ByteArray,
+  value v: value,
+  with: fn(ByteArray, value, value) ->
+    fn(fn(value) -> Pairs<ByteArray, value>, fn() -> Pairs<ByteArray, value>) ->
+      Pairs<ByteArray, value>,
+) -> Pairs<ByteArray, value> {
+  when self is {
+    [] -> [Pair(k, v)]
+    [Pair(k2, v2), ..rest] ->
+      if builtin.less_than_bytearray(k, k2) {
+        [Pair(k, v), ..self]
+      } else {
+        if k == k2 {
+          with(k, v, v2)(
+            fn(combined) { [Pair(k, combined), ..rest] },
+            fn() { rest },
+          )
+        } else {
+          [Pair(k2, v2), ..do_insert_with_alt(rest, k, v, with)]
         }
       }
   }

--- a/lib/aiken/collection/dict.ak
+++ b/lib/aiken/collection/dict.ak
@@ -13,6 +13,7 @@
 //// > [`dict.from_ascending_list`](#from_ascending_list).
 
 use aiken/builtin
+use aiken/collection/dict/union.{UnionStrategy}
 
 /// An opaque `Dict`. The type is opaque because the module maintains some
 /// invariant, namely: there's only one occurrence of a given key in the dictionary.
@@ -755,16 +756,14 @@ pub fn insert_with_alt(
   self: Dict<key, value>,
   key k: ByteArray,
   value v: value,
-  with: fn(ByteArray, value, value) ->
-    fn(fn(value) -> Pairs<ByteArray, value>, fn() -> Pairs<ByteArray, value>) ->
-      Pairs<ByteArray, value>,
+  with: UnionStrategy<ByteArray, value>,
 ) -> Dict<key, value> {
   Dict {
     inner: do_insert_with_alt(
       self.inner,
       k,
       v,
-      fn(k, v1, v2) { with(k, v2, v1) },
+      fn(k, v1, v2, some, none) { with(k, v2, v1, some, none) },
     ),
   }
 }
@@ -783,13 +782,10 @@ test insert_with_1() {
 }
 
 test insert_with_alt_1() {
-  let sum =
-    fn(_k, a, b) { fn(som, _non) { som(a + b) } }
-
   let result =
     empty
-      |> insert_with_alt(key: "foo", value: 1, with: sum)
-      |> insert_with_alt(key: "bar", value: 2, with: sum)
+      |> insert_with_alt(key: "foo", value: 1, with: union.sum())
+      |> insert_with_alt(key: "bar", value: 2, with: union.sum())
       |> to_pairs()
 
   result == [Pair("bar", 2), Pair("foo", 1)]
@@ -1050,9 +1046,7 @@ pub fn union_with(
 pub fn union_with_alt(
   left: Dict<key, value>,
   right: Dict<key, value>,
-  with: fn(ByteArray, value, value) ->
-    fn(fn(value) -> Pairs<ByteArray, value>, fn() -> Pairs<ByteArray, value>) ->
-      Pairs<ByteArray, value>,
+  with: UnionStrategy<ByteArray, value>,
 ) -> Dict<key, value> {
   Dict { inner: do_union_with_alt(left.inner, right.inner, with) }
 }
@@ -1072,9 +1066,7 @@ fn do_union_with(
 fn do_union_with_alt(
   left: Pairs<ByteArray, value>,
   right: Pairs<ByteArray, value>,
-  with: fn(ByteArray, value, value) ->
-    fn(fn(value) -> Pairs<ByteArray, value>, fn() -> Pairs<ByteArray, value>) ->
-      Pairs<ByteArray, value>,
+  with: UnionStrategy<ByteArray, value>,
 ) -> Pairs<ByteArray, value> {
   when left is {
     [] -> right
@@ -1111,9 +1103,7 @@ fn do_insert_with_alt(
   self: Pairs<ByteArray, value>,
   key k: ByteArray,
   value v: value,
-  with: fn(ByteArray, value, value) ->
-    fn(fn(value) -> Pairs<ByteArray, value>, fn() -> Pairs<ByteArray, value>) ->
-      Pairs<ByteArray, value>,
+  with: UnionStrategy<ByteArray, value>,
 ) -> Pairs<ByteArray, value> {
   when self is {
     [] -> [Pair(k, v)]
@@ -1122,7 +1112,10 @@ fn do_insert_with_alt(
         [Pair(k, v), ..self]
       } else {
         if k == k2 {
-          with(k, v, v2)(
+          with(
+            k,
+            v,
+            v2,
             fn(combined) { [Pair(k, combined), ..rest] },
             fn() { rest },
           )

--- a/lib/aiken/collection/dict.ak
+++ b/lib/aiken/collection/dict.ak
@@ -161,7 +161,8 @@ pub fn from_pairs(self: Pairs<ByteArray, value>) -> Dict<key, value> {
 fn do_from_pairs(xs: Pairs<ByteArray, value>) -> Pairs<ByteArray, value> {
   when xs is {
     [] -> []
-    [Pair(k, v), ..rest] -> do_insert(do_from_pairs(rest), k, v)
+    [Pair(k, v), ..rest] ->
+      do_insert_with(do_from_pairs(rest), k, v, union.keep_left())
   }
 }
 
@@ -729,14 +730,13 @@ test insert_2() {
 /// to the merge function, and the new value is passed as the third argument.
 ///
 /// ```aiken
-/// let sum =
-///   fn (_k, a, b) { Some(a + b) }
+/// use aiken/collection/dict/union
 ///
 /// let result =
 ///   dict.empty
-///     |> dict.insert_with(key: "a", value: 1, with: sum)
-///     |> dict.insert_with(key: "b", value: 2, with: sum)
-///     |> dict.insert_with(key: "a", value: 3, with: sum)
+///     |> dict.insert_with(key: "a", value: 1, with: union.sum())
+///     |> dict.insert_with(key: "b", value: 2, with: union.sum())
+///     |> dict.insert_with(key: "a", value: 3, with: union.sum())
 ///     |> dict.to_pairs()
 ///
 /// result == [Pair("a", 4), Pair("b", 2)]
@@ -745,21 +745,10 @@ pub fn insert_with(
   self: Dict<key, value>,
   key k: ByteArray,
   value v: value,
-  with: fn(ByteArray, value, value) -> Option<value>,
-) -> Dict<key, value> {
-  Dict {
-    inner: do_insert_with(self.inner, k, v, fn(k, v1, v2) { with(k, v2, v1) }),
-  }
-}
-
-pub fn insert_with_alt(
-  self: Dict<key, value>,
-  key k: ByteArray,
-  value v: value,
   with: UnionStrategy<ByteArray, value>,
 ) -> Dict<key, value> {
   Dict {
-    inner: do_insert_with_alt(
+    inner: do_insert_with(
       self.inner,
       k,
       v,
@@ -769,37 +758,21 @@ pub fn insert_with_alt(
 }
 
 test insert_with_1() {
-  let sum =
-    fn(_k, a, b) { Some(a + b) }
-
   let result =
     empty
-      |> insert_with(key: "foo", value: 1, with: sum)
-      |> insert_with(key: "bar", value: 2, with: sum)
-      |> to_pairs()
-
-  result == [Pair("bar", 2), Pair("foo", 1)]
-}
-
-test insert_with_alt_1() {
-  let result =
-    empty
-      |> insert_with_alt(key: "foo", value: 1, with: union.sum())
-      |> insert_with_alt(key: "bar", value: 2, with: union.sum())
+      |> insert_with(key: "foo", value: 1, with: union.sum())
+      |> insert_with(key: "bar", value: 2, with: union.sum())
       |> to_pairs()
 
   result == [Pair("bar", 2), Pair("foo", 1)]
 }
 
 test insert_with_2() {
-  let sum =
-    fn(_k, a, b) { Some(a + b) }
-
   let result =
     empty
-      |> insert_with(key: "foo", value: 1, with: sum)
-      |> insert_with(key: "bar", value: 2, with: sum)
-      |> insert_with(key: "foo", value: 3, with: sum)
+      |> insert_with(key: "foo", value: 1, with: union.sum())
+      |> insert_with(key: "bar", value: 2, with: union.sum())
+      |> insert_with(key: "foo", value: 3, with: union.sum())
       |> to_pairs()
 
   result == [Pair("bar", 2), Pair("foo", 4)]
@@ -807,11 +780,11 @@ test insert_with_2() {
 
 test insert_with_3() {
   let with =
-    fn(k, a, _b) {
+    fn(k, a, _b, keep, discard) {
       if k == "foo" {
-        Some(a)
+        keep(a)
       } else {
-        None
+        discard()
       }
     }
 
@@ -1038,23 +1011,15 @@ test union_4() {
 pub fn union_with(
   left: Dict<key, value>,
   right: Dict<key, value>,
-  with: fn(ByteArray, value, value) -> Option<value>,
-) -> Dict<key, value> {
-  Dict { inner: do_union_with(left.inner, right.inner, with) }
-}
-
-pub fn union_with_alt(
-  left: Dict<key, value>,
-  right: Dict<key, value>,
   with: UnionStrategy<ByteArray, value>,
 ) -> Dict<key, value> {
-  Dict { inner: do_union_with_alt(left.inner, right.inner, with) }
+  Dict { inner: do_union_with(left.inner, right.inner, with) }
 }
 
 fn do_union_with(
   left: Pairs<ByteArray, value>,
   right: Pairs<ByteArray, value>,
-  with: fn(ByteArray, value, value) -> Option<value>,
+  with: UnionStrategy<ByteArray, value>,
 ) -> Pairs<ByteArray, value> {
   when left is {
     [] -> right
@@ -1063,43 +1028,7 @@ fn do_union_with(
   }
 }
 
-fn do_union_with_alt(
-  left: Pairs<ByteArray, value>,
-  right: Pairs<ByteArray, value>,
-  with: UnionStrategy<ByteArray, value>,
-) -> Pairs<ByteArray, value> {
-  when left is {
-    [] -> right
-    [Pair(k, v), ..rest] ->
-      do_union_with_alt(rest, do_insert_with_alt(right, k, v, with), with)
-  }
-}
-
 fn do_insert_with(
-  self: Pairs<ByteArray, value>,
-  key k: ByteArray,
-  value v: value,
-  with: fn(ByteArray, value, value) -> Option<value>,
-) -> Pairs<ByteArray, value> {
-  when self is {
-    [] -> [Pair(k, v)]
-    [Pair(k2, v2), ..rest] ->
-      if builtin.less_than_bytearray(k, k2) {
-        [Pair(k, v), ..self]
-      } else {
-        if k == k2 {
-          when with(k, v, v2) is {
-            Some(combined) -> [Pair(k, combined), ..rest]
-            None -> rest
-          }
-        } else {
-          [Pair(k2, v2), ..do_insert_with(rest, k, v, with)]
-        }
-      }
-  }
-}
-
-fn do_insert_with_alt(
   self: Pairs<ByteArray, value>,
   key k: ByteArray,
   value v: value,
@@ -1120,7 +1049,7 @@ fn do_insert_with_alt(
             fn() { rest },
           )
         } else {
-          [Pair(k2, v2), ..do_insert_with_alt(rest, k, v, with)]
+          [Pair(k2, v2), ..do_insert_with(rest, k, v, with)]
         }
       }
   }
@@ -1136,7 +1065,7 @@ test union_with_1() {
       |> insert(bar, 42)
       |> insert(foo, 1337)
 
-  let result = union_with(left, right, with: fn(_, l, r) { Some(l + r) })
+  let result = union_with(left, right, with: union.sum())
 
   result == from_pairs([Pair(foo, 1351), Pair(bar, 42)])
 }

--- a/lib/aiken/collection/dict/union.ak
+++ b/lib/aiken/collection/dict/union.ak
@@ -3,7 +3,7 @@ pub type UnionStrategy<key, value> =
   fn(key, value, value, KeepValue<key, value>, DiscardValue<key, value>) ->
     Pairs<key, value>
 
-/// A callback to keep a combined valueat a given key
+/// A callback to keep a combined value at a given key
 pub type KeepValue<key, value> =
   fn(value) -> Pairs<key, value>
 

--- a/lib/aiken/collection/dict/union.ak
+++ b/lib/aiken/collection/dict/union.ak
@@ -1,0 +1,47 @@
+/// A strategy for combining two values in a dictionnary that belong to the same key.
+pub type UnionStrategy<key, value> =
+  fn(key, value, value, KeepValue<key, value>, DiscardValue<key, value>) ->
+    Pairs<key, value>
+
+/// A callback to keep a combined valueat a given key
+pub type KeepValue<key, value> =
+  fn(value) -> Pairs<key, value>
+
+/// A callback to discard a value at a given key
+pub type DiscardValue<key, value> =
+  fn() -> Pairs<key, value>
+
+/// A strategy which always fail, enforcing the dict contains no duplicate.
+pub fn expect_no_duplicate() -> UnionStrategy<key, value> {
+  fn(_, _, _, _, _) {
+    fail @"unexpected duplicate key found in dict."
+  }
+}
+
+/// Combine values by keeping the values present in the left-most dict.
+pub fn keep_left() -> UnionStrategy<key, value> {
+  fn(_key, left, _right, keep, _discard) { keep(left) }
+}
+
+/// Combine values by keeping the values present in the left-most dict.
+pub fn keep_right() -> UnionStrategy<key, value> {
+  fn(_key, _left, right, keep, _discard) { keep(right) }
+}
+
+/// Combine values by taking their sum.
+pub fn sum() -> UnionStrategy<key, Int> {
+  fn(_key, left, right, keep, _discard) { keep(left + right) }
+}
+
+/// Combine values by taking their sum, only if it is non-null. Otherwise,
+/// discard the key/value entirely.
+pub fn sum_if_non_zero() -> UnionStrategy<key, Int> {
+  fn(_key, left, right, keep, discard) {
+    let value = left + right
+    if value == 0 {
+      discard()
+    } else {
+      keep(value)
+    }
+  }
+}

--- a/lib/cardano/assets.ak
+++ b/lib/cardano/assets.ak
@@ -1,5 +1,6 @@
 use aiken/builtin
 use aiken/collection/dict.{Dict, from_ascending_pairs_with}
+use aiken/collection/dict/union
 use aiken/collection/list
 use aiken/crypto.{Blake2b_224, Hash, Script}
 use aiken/option
@@ -77,14 +78,7 @@ pub fn from_asset_list(xs: Pairs<PolicyId, Pairs<AssetName, Int>>) -> Value {
           expect Pair(p, [_, ..] as x) = inner
           x
             |> from_ascending_pairs_with(fn(v) { v != 0 })
-            |> dict.insert_with_alt(
-                acc,
-                p,
-                _,
-                fn(_, _, _) {
-                  fail @"Duplicate policy in the asset list."
-                },
-              )
+            |> dict.insert_with_alt(acc, p, _, union.expect_no_duplicate())
         },
       )
     |> Value
@@ -555,30 +549,19 @@ pub fn add(
     self
   } else {
     let helper =
-      fn(_, left, _right) {
-        fn(som, non) {
-          let inner_result =
-            dict.insert_with_alt(
-              left,
-              asset_name,
-              quantity,
-              fn(_k, ql, qr) {
-                fn(som, non) {
-                  let q = ql + qr
-                  if q == 0 {
-                    non()
-                  } else {
-                    som(q)
-                  }
-                }
-              },
-            )
+      fn(_, left, _right, keep, discard) {
+        let inner_result =
+          dict.insert_with_alt(
+            left,
+            asset_name,
+            quantity,
+            union.sum_if_non_zero(),
+          )
 
-          if dict.is_empty(inner_result) {
-            non()
-          } else {
-            som(inner_result)
-          }
+        if dict.is_empty(inner_result) {
+          discard()
+        } else {
+          keep(inner_result)
         }
       }
 
@@ -638,28 +621,12 @@ pub fn merge(left v0: Value, right v1: Value) -> Value {
     dict.union_with_alt(
       v0.inner,
       v1.inner,
-      fn(_, a0, a1) {
-        fn(som, non) {
-          let result =
-            dict.union_with_alt(
-              a0,
-              a1,
-              fn(_, q0, q1) {
-                fn(som, non) {
-                  let q = q0 + q1
-                  if q == 0 {
-                    non()
-                  } else {
-                    som(q)
-                  }
-                }
-              },
-            )
-          if dict.is_empty(result) {
-            non()
-          } else {
-            som(result)
-          }
+      fn(_, a0, a1, keep, discard) {
+        let result = dict.union_with_alt(a0, a1, union.sum_if_non_zero())
+        if dict.is_empty(result) {
+          discard()
+        } else {
+          keep(result)
         }
       },
     ),

--- a/lib/cardano/assets.ak
+++ b/lib/cardano/assets.ak
@@ -78,7 +78,7 @@ pub fn from_asset_list(xs: Pairs<PolicyId, Pairs<AssetName, Int>>) -> Value {
           expect Pair(p, [_, ..] as x) = inner
           x
             |> from_ascending_pairs_with(fn(v) { v != 0 })
-            |> dict.insert_with_alt(acc, p, _, union.expect_no_duplicate())
+            |> dict.insert_with(acc, p, _, union.expect_no_duplicate())
         },
       )
     |> Value
@@ -551,12 +551,7 @@ pub fn add(
     let helper =
       fn(_, left, _right, keep, discard) {
         let inner_result =
-          dict.insert_with_alt(
-            left,
-            asset_name,
-            quantity,
-            union.sum_if_non_zero(),
-          )
+          dict.insert_with(left, asset_name, quantity, union.sum_if_non_zero())
 
         if dict.is_empty(inner_result) {
           discard()
@@ -566,7 +561,7 @@ pub fn add(
       }
 
     Value(
-      dict.insert_with_alt(
+      dict.insert_with(
         self.inner,
         policy_id,
         dict.from_ascending_pairs([Pair(asset_name, quantity)]),
@@ -618,11 +613,11 @@ test add_5() {
 /// Combine two `Value` together.
 pub fn merge(left v0: Value, right v1: Value) -> Value {
   Value(
-    dict.union_with_alt(
+    dict.union_with(
       v0.inner,
       v1.inner,
       fn(_, a0, a1, keep, discard) {
-        let result = dict.union_with_alt(a0, a1, union.sum_if_non_zero())
+        let result = dict.union_with(a0, a1, union.sum_if_non_zero())
         if dict.is_empty(result) {
           discard()
         } else {

--- a/lib/cardano/assets.ak
+++ b/lib/cardano/assets.ak
@@ -77,7 +77,7 @@ pub fn from_asset_list(xs: Pairs<PolicyId, Pairs<AssetName, Int>>) -> Value {
           expect Pair(p, [_, ..] as x) = inner
           x
             |> from_ascending_pairs_with(fn(v) { v != 0 })
-            |> dict.insert_with(
+            |> dict.insert_with_alt(
                 acc,
                 p,
                 _,
@@ -556,29 +556,34 @@ pub fn add(
   } else {
     let helper =
       fn(_, left, _right) {
-        let inner_result =
-          dict.insert_with(
-            left,
-            asset_name,
-            quantity,
-            fn(_k, ql, qr) {
-              let q = ql + qr
-              if q == 0 {
-                None
-              } else {
-                Some(q)
-              }
-            },
-          )
-        if dict.is_empty(inner_result) {
-          None
-        } else {
-          Some(inner_result)
+        fn(som, non) {
+          let inner_result =
+            dict.insert_with_alt(
+              left,
+              asset_name,
+              quantity,
+              fn(_k, ql, qr) {
+                fn(som, non) {
+                  let q = ql + qr
+                  if q == 0 {
+                    non()
+                  } else {
+                    som(q)
+                  }
+                }
+              },
+            )
+
+          if dict.is_empty(inner_result) {
+            non()
+          } else {
+            som(inner_result)
+          }
         }
       }
 
     Value(
-      dict.insert_with(
+      dict.insert_with_alt(
         self.inner,
         policy_id,
         dict.from_ascending_pairs([Pair(asset_name, quantity)]),
@@ -630,27 +635,31 @@ test add_5() {
 /// Combine two `Value` together.
 pub fn merge(left v0: Value, right v1: Value) -> Value {
   Value(
-    dict.union_with(
+    dict.union_with_alt(
       v0.inner,
       v1.inner,
       fn(_, a0, a1) {
-        let result =
-          dict.union_with(
-            a0,
-            a1,
-            fn(_, q0, q1) {
-              let q = q0 + q1
-              if q == 0 {
-                None
-              } else {
-                Some(q)
-              }
-            },
-          )
-        if dict.is_empty(result) {
-          None
-        } else {
-          Some(result)
+        fn(som, non) {
+          let result =
+            dict.union_with_alt(
+              a0,
+              a1,
+              fn(_, q0, q1) {
+                fn(som, non) {
+                  let q = q0 + q1
+                  if q == 0 {
+                    non()
+                  } else {
+                    som(q)
+                  }
+                }
+              },
+            )
+          if dict.is_empty(result) {
+            non()
+          } else {
+            som(result)
+          }
         }
       },
     ),

--- a/lib/cardano/assets.ak
+++ b/lib/cardano/assets.ak
@@ -1,9 +1,10 @@
 use aiken/builtin
 use aiken/collection/dict.{Dict, from_ascending_pairs_with}
-use aiken/collection/dict/union
+use aiken/collection/dict/union as dict_union
 use aiken/collection/list
 use aiken/crypto.{Blake2b_224, Hash, Script}
 use aiken/option
+use cardano/assets/union
 
 /// Lovelace is now a type wrapper for Int.
 pub type Lovelace =
@@ -78,7 +79,7 @@ pub fn from_asset_list(xs: Pairs<PolicyId, Pairs<AssetName, Int>>) -> Value {
           expect Pair(p, [_, ..] as x) = inner
           x
             |> from_ascending_pairs_with(fn(v) { v != 0 })
-            |> dict.insert_with(acc, p, _, union.expect_no_duplicate())
+            |> dict.insert_with(acc, p, _, dict_union.expect_no_duplicate())
         },
       )
     |> Value
@@ -551,7 +552,12 @@ pub fn add(
     let helper =
       fn(_, left, _right, keep, discard) {
         let inner_result =
-          dict.insert_with(left, asset_name, quantity, union.sum_if_non_zero())
+          dict.insert_with(
+            left,
+            asset_name,
+            quantity,
+            dict_union.sum_if_non_zero(),
+          )
 
         if dict.is_empty(inner_result) {
           discard()
@@ -617,7 +623,7 @@ pub fn merge(left v0: Value, right v1: Value) -> Value {
       v0.inner,
       v1.inner,
       fn(_, a0, a1, keep, discard) {
-        let result = dict.union_with(a0, a1, union.sum_if_non_zero())
+        let result = dict.union_with(a0, a1, dict_union.sum_if_non_zero())
         if dict.is_empty(result) {
           discard()
         } else {
@@ -789,7 +795,7 @@ pub fn flatten(self: Value) -> List<(PolicyId, AssetName, Int)> {
 /// When the transform function returns `None`, the result is discarded altogether.
 pub fn flatten_with(
   self: Value,
-  with: fn(PolicyId, AssetName, Int) -> Option<result>,
+  with: union.UnionStrategy<result>,
 ) -> List<result> {
   dict.foldr(
     self.inner,
@@ -799,10 +805,13 @@ pub fn flatten_with(
         asset_list,
         value,
         fn(asset_name, quantity, xs) {
-          when with(policy_id, asset_name, quantity) is {
-            None -> xs
-            Some(x) -> [x, ..xs]
-          }
+          with(
+            policy_id,
+            asset_name,
+            quantity,
+            fn(x) { [x, ..xs] },
+            fn() { xs },
+          )
         },
       )
     },
@@ -810,7 +819,7 @@ pub fn flatten_with(
 }
 
 test flatten_with_1() {
-  flatten_with(zero, fn(p, a, q) { Some((p, a, q)) }) == []
+  flatten_with(zero, union.triple()) == []
 }
 
 test flatten_with_2() {
@@ -822,11 +831,11 @@ test flatten_with_2() {
 
   flatten_with(
     v,
-    fn(p, a, q) {
+    fn(p, a, q, keep, discard) {
       if q == 42 {
-        Some((p, a))
+        keep((p, a))
       } else {
-        None
+        discard()
       }
     },
   ) == [("a", "2"), ("b", "")]

--- a/lib/cardano/assets/union.ak
+++ b/lib/cardano/assets/union.ak
@@ -1,0 +1,27 @@
+use aiken/crypto.{Blake2b_224, Hash, Script}
+
+/// A strategy for combining two values in a dictionnary that belong to the same key.
+pub type UnionStrategy<result> =
+  fn(
+    Hash<Blake2b_224, Script>,
+    ByteArray,
+    Int,
+    KeepResult<result>,
+    DiscardResult<result>,
+  ) ->
+    List<result>
+
+/// A callback to keep result at a given key
+pub type KeepResult<result> =
+  fn(result) -> List<result>
+
+/// A callback to discard result at a given key
+pub type DiscardResult<result> =
+  fn() -> List<result>
+
+/// Combine values by keeping them in a 3-tuple.
+pub fn triple() -> UnionStrategy<(Hash<Blake2b_224, Script>, ByteArray, Int)> {
+  fn(policy_id, asset_name, quantity, keep, _discard) {
+    keep((policy_id, asset_name, quantity))
+  }
+}


### PR DESCRIPTION
Here's some benchmarks so far

Scott
    │ PASS [mem:   37338, cpu:   10429873] add_1
    │ PASS [mem:   66298, cpu:   18740888] add_2
    │ PASS [mem:   69931, cpu:   19660091] add_3
    │ PASS [mem:    4734, cpu:    1887659] add_4
    │ PASS [mem:    9137, cpu:    2772374] add_5
    
 Option
    │ PASS [mem:   41070, cpu:   11595603] add_1
    │ PASS [mem:   69630, cpu:   19842618] add_2
    │ PASS [mem:   82835, cpu:   24136523] add_3
    │ PASS [mem:    4734, cpu:    1887659] add_4
    │ PASS [mem:    9737, cpu:    2868374] add_5
    
    
    
    
 Scott
    │ PASS [mem:   45554, cpu:   13015185] merge_1
    │ PASS [mem:  185897, cpu:   55227410] merge_2
    │ PASS [mem:   73308, cpu:   20542533] merge_3
    │ PASS [mem:   47482, cpu:   13347917] merge_4
    │ PASS [mem:    7366, cpu:    2436653] merge_5
    
    
    
 Option
    │ PASS [mem:   48686, cpu:   14084915] merge_1
    │ PASS [mem:  185497, cpu:   55163410] merge_2
    │ PASS [mem:   76240, cpu:   21580263] merge_3
    │ PASS [mem:   50614, cpu:   14417647] merge_4
    │ PASS [mem:    8266, cpu:    2580653] merge_5
    
    
    
    
    