### PR TITLE
refactor: return None if index is negative in list.at function

### DIFF
--- a/lib/aiken/collection/list.ak
+++ b/lib/aiken/collection/list.ak
@@ -136,6 +136,8 @@ pub fn at(self: List<a>, index: Int) -> Option<a> {
     [x, ..xs] ->
       if index == 0 {
         Some(x)
+      } else if index < 0 {
+        None
       } else {
         at(xs, index - 1)
       }

--- a/lib/aiken/collection/list.ak
+++ b/lib/aiken/collection/list.ak
@@ -131,15 +131,21 @@ test any_3() {
 /// list.at([1, 2, 3], 42) == None
 /// ```
 pub fn at(self: List<a>, index: Int) -> Option<a> {
+  if index < 0 {
+    None
+  } else {
+    do_at(self, index)
+  }
+}
+
+fn do_at(self: List<a>, index: Int) -> Option<a> {
   when self is {
     [] -> None
     [x, ..xs] ->
       if index == 0 {
         Some(x)
-      } else if index < 0 {
-        None
       } else {
-        at(xs, index - 1)
+        do_at(xs, index - 1)
       }
   }
 }


### PR DESCRIPTION
## Changes

* Update `list.at` function to return `None` (directly) when `index` is negative.

## Benefit

* This is good for performance, because we don't need to go through all items even index is negative.