### PR TITLE
adding miller loops to crypto/bls12-381

### DIFF
--- a/aiken.toml
+++ b/aiken.toml
@@ -1,6 +1,6 @@
 name = "aiken-lang/stdlib"
 version = "main"
-compiler = "v1.1.19"
+compiler = "v1.1.17"
 plutus = "v3"
 description = "The Aiken Standard Library"
 

--- a/aiken.toml
+++ b/aiken.toml
@@ -1,6 +1,6 @@
 name = "aiken-lang/stdlib"
 version = "main"
-compiler = "v1.1.17"
+compiler = "v1.1.19"
 plutus = "v3"
 description = "The Aiken Standard Library"
 

--- a/lib/aiken/crypto/bls12_381/pairing.ak
+++ b/lib/aiken/crypto/bls12_381/pairing.ak
@@ -1,0 +1,28 @@
+use aiken/builtin.{bls12_381_final_verify, bls12_381_miller_loop}
+use aiken/crypto/bitwise.{State}
+use aiken/crypto/bls12_381/g1
+use aiken/crypto/bls12_381/g2
+use aiken/crypto/bls12_381/scalar.{Scalar}
+
+pub fn miller_loop(q: G1Element, p: G2Element) -> MillerLoopResult {
+  bls12_381_miller_loop(q, p)
+}
+
+pub fn final_exponentiation(
+  left: MillerLoopResult,
+  right: MillerLoopResult,
+) -> Bool {
+  bls12_381_final_verify(left, right)
+}
+
+test simple_miller_loop_with_final_exponentiation() {
+  let x: State<Scalar> = scalar.from_int(44203)
+  let u: G1Element = g1.generator |> g1.scale(x)
+  let mb: ByteArray = #"acab"
+  let m: State<Scalar> = scalar.from_bytes(mb)
+  let qmx: G2Element = g2.generator |> g2.scale(x) |> g2.scale(m)
+  let qm: G2Element = g2.scale(g2.generator, m)
+  let left: MillerLoopResult = miller_loop(u, qm)
+  let right: MillerLoopResult = miller_loop(g1.generator, qmx)
+  final_exponentiation(left, right)
+}


### PR DESCRIPTION
Was working on a project and realized the miller loop builtins do not have any wrappers in stdlib. Even if they are just wrappers at this point it would be nice to be feature complete here in the stdlib for bls12-381.