### PR TITLE
Remove Type Qualifiers for `IntervalBoundType` Values

### DIFF
--- a/lib/aiken/interval.test.ak
+++ b/lib/aiken/interval.test.ak
@@ -6,10 +6,10 @@ use aiken/interval.{
 
 const bound_type: Fuzzer<IntervalBoundType> =
   fuzz.either(
-    fuzz.map(fuzz.int(), IntervalBoundType.Finite),
+    fuzz.map(fuzz.int(), Finite),
     either(
-      constant(IntervalBoundType.NegativeInfinity),
-      constant(IntervalBoundType.PositiveInfinity),
+      constant(NegativeInfinity),
+      constant(PositiveInfinity),
     ),
   )
 


### PR DESCRIPTION
These qualifiers seem to cause failures in CI (particularly for generating the docs, `aiken docs -o docs`).

Successful build logs without the qualifiers (`stdlib` was imported from the branch of this PR, [`aiken.toml`](https://github.com/keyan-m/aiken-scott-utils/blob/b57e02ffe678b56e4d06797a6da256b385d90551/aiken.toml)):
https://github.com/keyan-m/aiken-scott-utils/actions/runs/19936241497/job/57161753335

Failed build logs with the qualifiers (`stdlib` from `aiken-lang` release `v3.0.0`, [`aiken.toml`](https://github.com/keyan-m/aiken-scott-utils/blob/39d1d6642f93e259f5fef6120b4a97bc37a6d932/aiken.toml)):
https://github.com/keyan-m/aiken-scott-utils/actions/runs/19936378072/job/57162252238
