### PR TITLE
Use builtin.null_list in both list and dict is_empty

### DIFF
--- a/lib/aiken/collection/dict.ak
+++ b/lib/aiken/collection/dict.ak
@@ -379,10 +379,7 @@ fn do_has_key(self: Pairs<ByteArray, value>, key k: ByteArray) -> Bool {
 /// dict.is_empty(dict.empty) == True
 /// ```
 pub fn is_empty(self: Dict<key, value>) -> Bool {
-  when self.inner is {
-    [] -> True
-    _ -> False
-  }
+  builtin.null_list(self.inner)
 }
 
 /// Extract all the keys present in a given `Dict`.

--- a/lib/aiken/collection/dict.ak
+++ b/lib/aiken/collection/dict.ak
@@ -379,7 +379,7 @@ fn do_has_key(self: Pairs<ByteArray, value>, key k: ByteArray) -> Bool {
 /// dict.is_empty(dict.empty) == True
 /// ```
 pub fn is_empty(self: Dict<key, value>) -> Bool {
-  builtin.null_list(self.inner)
+  self.inner == []
 }
 
 /// Extract all the keys present in a given `Dict`.

--- a/lib/aiken/collection/list.ak
+++ b/lib/aiken/collection/list.ak
@@ -205,10 +205,7 @@ pub fn head(self: List<a>) -> Option<a> {
 /// list.is_empty([1, 2, 3]) == False
 /// ```
 pub fn is_empty(self: List<a>) -> Bool {
-  when self is {
-    [] -> True
-    _ -> False
-  }
+  builtin.null_list(self)
 }
 
 /// Gets the index of an element of a list, if any. Otherwise, returns None.

--- a/lib/aiken/collection/list.ak
+++ b/lib/aiken/collection/list.ak
@@ -205,7 +205,7 @@ pub fn head(self: List<a>) -> Option<a> {
 /// list.is_empty([1, 2, 3]) == False
 /// ```
 pub fn is_empty(self: List<a>) -> Bool {
-  builtin.null_list(self)
+  self == []
 }
 
 /// Gets the index of an element of a list, if any. Otherwise, returns None.


### PR DESCRIPTION
Small optimization for list and dict `is_empty`, after noticing this behavior in tests:

```
const l = []

// [mem:   1.13 K, cpu: 293.09 K]
test bench_is_empty() {
  list.is_empty(l)
}

// [mem:    532.0, cpu: 138.53 K]
test bench_builtin() {
  builtin.null_list(l)
}

// EDIT: Test added
// [mem:    200.0, cpu:   16.1 K]
test bench_equal(){
  l == []
}

```